### PR TITLE
Add opencode as installer target with command generation and structure verification

### DIFF
--- a/tools/installer/main.go
+++ b/tools/installer/main.go
@@ -387,12 +387,20 @@ func copyFileWithMode(src, dst string, mode os.FileMode) error {
 	return nil
 }
 
+var supportedTargets = map[string]bool{
+	"codex": true, "claude": true, "antigravity": true, "opencode": true,
+}
+
+var supportedModes = map[string]bool{
+	"symlink": true, "copy": true,
+}
+
 func isSupportedTarget(target string) bool {
-	return target == "codex" || target == "claude" || target == "antigravity" || target == "opencode"
+	return supportedTargets[target]
 }
 
 func isSupportedMode(mode string) bool {
-	return mode == "symlink" || mode == "copy"
+	return supportedModes[mode]
 }
 
 func installOpenCodeCommands(repoRoot, targetRoot string, force bool) (int, error) {
@@ -427,7 +435,7 @@ func installOpenCodeCommands(repoRoot, targetRoot string, force bool) (int, erro
 			if dir == "." {
 				return nil
 			}
-			cmdRel = dir + ".md"
+			cmdRel = strings.ReplaceAll(dir, string(filepath.Separator), "/") + ".md"
 		} else if strings.HasSuffix(info.Name(), ".md") && dir == "." {
 			cmdRel = info.Name()
 		} else {
@@ -464,7 +472,7 @@ func verifyOpenCodeStructure(targetRoot string) error {
 
 	var cmdFiles []string
 	var emptyFiles []string
-	filepath.Walk(commandsDir, func(path string, fi os.FileInfo, walkErr error) error {
+	if err := filepath.Walk(commandsDir, func(path string, fi os.FileInfo, walkErr error) error {
 		if walkErr != nil || fi.IsDir() {
 			return nil
 		}
@@ -482,7 +490,9 @@ func verifyOpenCodeStructure(targetRoot string) error {
 			emptyFiles = append(emptyFiles, rel)
 		}
 		return nil
-	})
+	}); err != nil {
+		return fmt.Errorf("walk commands dir: %w", err)
+	}
 
 	var problems []string
 	if len(cmdFiles) == 0 {

--- a/tools/installer/main.go
+++ b/tools/installer/main.go
@@ -51,7 +51,7 @@ func parseFlags(args []string) (config, error) {
 	fs.SetOutput(io.Discard)
 
 	fs.StringVar(&cfg.RepoRoot, "repo-root", "", "repository root")
-	fs.StringVar(&cfg.Target, "target", "", "install target: codex, claude, antigravity")
+	fs.StringVar(&cfg.Target, "target", "", "install target: codex, claude, antigravity, opencode")
 	fs.StringVar(&cfg.Mode, "mode", "", "install mode: symlink, copy")
 	fs.BoolVar(&cfg.Force, "force", false, "replace existing paths")
 
@@ -71,7 +71,7 @@ func parseFlags(args []string) (config, error) {
 }
 
 func usageErr(err error) error {
-	return fmt.Errorf("%w\n\nUsage: ./install.sh [--target codex|claude|antigravity] [--mode symlink|copy] [--force]", err)
+	return fmt.Errorf("%w\n\nUsage: ./install.sh [--target codex|claude|antigravity|opencode] [--mode symlink|copy] [--force]", err)
 }
 
 func promptMissing(cfg *config) error {
@@ -92,6 +92,7 @@ func promptMissing(cfg *config) error {
 					huh.NewOption("Codex", "codex"),
 					huh.NewOption("Claude", "claude"),
 					huh.NewOption("Antigravity", "antigravity"),
+					huh.NewOption("OpenCode", "opencode"),
 				).
 				Value(&cfg.Target),
 			huh.NewSelect[string]().
@@ -159,6 +160,19 @@ func install(cfg config) error {
 	hubReadme := filepath.Join(hubDir, "README.md")
 	if err := copyFile(filepath.Join(cfg.RepoRoot, ".mothership", "hub", "README.md"), hubReadme, cfg.Force); err != nil {
 		return err
+	}
+
+	if cfg.Target == "opencode" {
+		cmdCount, err := installOpenCodeCommands(cfg.RepoRoot, targetRoot, cfg.Force)
+		if err != nil {
+			return err
+		}
+
+		if err := verifyOpenCodeStructure(targetRoot); err != nil {
+			return fmt.Errorf("post-install verification: %w", err)
+		}
+
+		fmt.Printf("  opencode commands: %d installed in %s\n", cmdCount, filepath.Join(targetRoot, "commands"))
 	}
 
 	fmt.Printf("Installed Mothership to %s\n", targetRoot)
@@ -232,9 +246,39 @@ func targetRootFor(target string) string {
 		return filepath.Join(os.Getenv("HOME"), ".claude")
 	case "antigravity":
 		return filepath.Join(os.Getenv("HOME"), ".antigravity")
+	case "opencode":
+		return resolveOpenCodeDir()
 	default:
 		return ""
 	}
+}
+
+func resolveOpenCodeDir() string {
+	if root := os.Getenv("OPENCODE_HOME"); root != "" {
+		return root
+	}
+
+	home := os.Getenv("HOME")
+
+	searchPaths := []string{}
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		searchPaths = append(searchPaths, filepath.Join(xdg, "opencode"))
+	}
+	searchPaths = append(searchPaths,
+		filepath.Join(home, ".config", "opencode"),
+		filepath.Join(home, ".opencode"),
+	)
+
+	for _, candidate := range searchPaths {
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
+	}
+
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "opencode")
+	}
+	return filepath.Join(home, ".config", "opencode")
 }
 
 func installPath(src, dst, mode string, force bool) error {
@@ -344,9 +388,113 @@ func copyFileWithMode(src, dst string, mode os.FileMode) error {
 }
 
 func isSupportedTarget(target string) bool {
-	return target == "codex" || target == "claude" || target == "antigravity"
+	return target == "codex" || target == "claude" || target == "antigravity" || target == "opencode"
 }
 
 func isSupportedMode(mode string) bool {
 	return mode == "symlink" || mode == "copy"
+}
+
+func installOpenCodeCommands(repoRoot, targetRoot string, force bool) (int, error) {
+	commandsDir := filepath.Join(targetRoot, "commands")
+	if err := os.MkdirAll(commandsDir, 0o755); err != nil {
+		return 0, fmt.Errorf("create commands dir: %w", err)
+	}
+
+	skillsDir := filepath.Join(repoRoot, "skills")
+	var count int
+
+	err := filepath.Walk(skillsDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(skillsDir, path)
+		if relErr != nil {
+			return fmt.Errorf("compute relative path for %s: %w", path, relErr)
+		}
+
+		if strings.HasPrefix(rel, ".system") {
+			return nil
+		}
+
+		var cmdRel string
+		dir := filepath.Dir(rel)
+		if info.Name() == "SKILL.md" {
+			if dir == "." {
+				return nil
+			}
+			cmdRel = dir + ".md"
+		} else if strings.HasSuffix(info.Name(), ".md") && dir == "." {
+			cmdRel = info.Name()
+		} else {
+			return nil
+		}
+
+		cmdFile := filepath.Join(commandsDir, cmdRel)
+		if err := copyFile(path, cmdFile, force); err != nil {
+			return fmt.Errorf("install command %s: %w", cmdRel, err)
+		}
+
+		count++
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("walk skills for opencode commands: %w", err)
+	}
+
+	return count, nil
+}
+
+func verifyOpenCodeStructure(targetRoot string) error {
+	commandsDir := filepath.Join(targetRoot, "commands")
+	info, err := os.Stat(commandsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("commands directory missing: %s", commandsDir)
+		}
+		return fmt.Errorf("inspect commands dir: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("commands path is not a directory: %s", commandsDir)
+	}
+
+	var cmdFiles []string
+	var emptyFiles []string
+	filepath.Walk(commandsDir, func(path string, fi os.FileInfo, walkErr error) error {
+		if walkErr != nil || fi.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(commandsDir, path)
+		if relErr != nil {
+			rel = path
+		}
+		cmdFiles = append(cmdFiles, rel)
+
+		if fi.Size() == 0 {
+			emptyFiles = append(emptyFiles, rel)
+		}
+		return nil
+	})
+
+	var problems []string
+	if len(cmdFiles) == 0 {
+		problems = append(problems, "no command files found in commands/")
+	}
+	if len(emptyFiles) > 0 {
+		problems = append(problems, fmt.Sprintf("empty command files: %s", strings.Join(emptyFiles, ", ")))
+	}
+
+	if len(problems) > 0 {
+		return fmt.Errorf("structure issues: %s", strings.Join(problems, "; "))
+	}
+
+	return nil
 }

--- a/tools/installer/main_test.go
+++ b/tools/installer/main_test.go
@@ -106,3 +106,145 @@ func writeFile(t *testing.T, path, contents string) {
 		t.Fatalf("WriteFile(%q) error = %v", path, err)
 	}
 }
+
+func makeValidRepo(t *testing.T) string {
+	t.Helper()
+	repoRoot := t.TempDir()
+	mkdirAll(t, filepath.Join(repoRoot, "skills", "commit"))
+	mkdirAll(t, filepath.Join(repoRoot, "skills", "obra", "creating-plan"))
+	mkdirAll(t, filepath.Join(repoRoot, "skills", ".system", "imagegen"))
+	mkdirAll(t, filepath.Join(repoRoot, "agents"))
+	mkdirAll(t, filepath.Join(repoRoot, "mothership-config"))
+	mkdirAll(t, filepath.Join(repoRoot, ".mothership", "hub"))
+	writeFile(t, filepath.Join(repoRoot, ".mothership", "hub", "README.md"), "hub contract")
+	writeFile(t, filepath.Join(repoRoot, "skills", "commit", "SKILL.md"), "# Commit Skill\nCreate a git commit.")
+	writeFile(t, filepath.Join(repoRoot, "skills", "obra", "creating-plan", "SKILL.md"), "# Creating Plan\nDesign an implementation plan.")
+	writeFile(t, filepath.Join(repoRoot, "skills", ".system", "imagegen", "SKILL.md"), "# Image Gen\nInternal skill.")
+	writeFile(t, filepath.Join(repoRoot, "skills", "risk-assessment.md"), "# Risk Assessment\nAssess project risks.")
+	return repoRoot
+}
+
+func TestInstallOpenCodeTarget(t *testing.T) {
+	repoRoot := makeValidRepo(t)
+	targetRoot := filepath.Join(t.TempDir(), "opencode")
+	t.Setenv("OPENCODE_HOME", targetRoot)
+
+	cfg := config{
+		RepoRoot: repoRoot,
+		Target:   "opencode",
+		Mode:     "copy",
+	}
+
+	if err := install(cfg); err != nil {
+		t.Fatalf("install() error = %v", err)
+	}
+
+	// Standard dirs installed
+	for _, rel := range []string{"skills", "agents", "mothership-config"} {
+		p := filepath.Join(targetRoot, rel)
+		if info, err := os.Stat(p); err != nil || !info.IsDir() {
+			t.Fatalf("expected directory %s, got err=%v isDir=%v", p, err, info != nil && info.IsDir())
+		}
+	}
+
+	// Commands from SKILL.md
+	cmdCommit := filepath.Join(targetRoot, "commands", "commit.md")
+	if data, err := os.ReadFile(cmdCommit); err != nil {
+		t.Fatalf("command %s missing: %v", cmdCommit, err)
+	} else if !strings.Contains(string(data), "Commit Skill") {
+		t.Fatalf("command %s has wrong content: %s", cmdCommit, string(data))
+	}
+
+	// Nested SKILL.md → nested command
+	cmdPlan := filepath.Join(targetRoot, "commands", "obra", "creating-plan.md")
+	if _, err := os.Stat(cmdPlan); err != nil {
+		t.Fatalf("nested command %s missing: %v", cmdPlan, err)
+	}
+
+	// Standalone .md in skills root → command
+	cmdRisk := filepath.Join(targetRoot, "commands", "risk-assessment.md")
+	if _, err := os.Stat(cmdRisk); err != nil {
+		t.Fatalf("standalone command %s missing: %v", cmdRisk, err)
+	}
+
+	// .system skills excluded
+	cmdSystem := filepath.Join(targetRoot, "commands", ".system", "imagegen.md")
+	if _, err := os.Stat(cmdSystem); !os.IsNotExist(err) {
+		t.Fatalf("system command %s should not exist", cmdSystem)
+	}
+}
+
+func TestVerifyOpenCodeStructure(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		root := t.TempDir()
+		mkdirAll(t, filepath.Join(root, "commands"))
+		writeFile(t, filepath.Join(root, "commands", "test.md"), "# Test")
+
+		if err := verifyOpenCodeStructure(root); err != nil {
+			t.Fatalf("verifyOpenCodeStructure() error = %v", err)
+		}
+	})
+
+	t.Run("missing commands dir", func(t *testing.T) {
+		root := t.TempDir()
+		err := verifyOpenCodeStructure(root)
+		if err == nil {
+			t.Fatal("expected error for missing commands dir")
+		}
+		if !strings.Contains(err.Error(), "commands directory missing") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty commands dir", func(t *testing.T) {
+		root := t.TempDir()
+		mkdirAll(t, filepath.Join(root, "commands"))
+
+		err := verifyOpenCodeStructure(root)
+		if err == nil {
+			t.Fatal("expected error for empty commands dir")
+		}
+		if !strings.Contains(err.Error(), "no command files") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestResolveOpenCodeDir(t *testing.T) {
+	t.Run("OPENCODE_HOME takes priority", func(t *testing.T) {
+		custom := filepath.Join(t.TempDir(), "custom-opencode")
+		mkdirAll(t, custom)
+		t.Setenv("OPENCODE_HOME", custom)
+		// Clear XDG to avoid interference
+		t.Setenv("XDG_CONFIG_HOME", "")
+
+		got := resolveOpenCodeDir()
+		if got != custom {
+			t.Fatalf("resolveOpenCodeDir() = %q, want %q", got, custom)
+		}
+	})
+
+	t.Run("XDG_CONFIG_HOME fallback", func(t *testing.T) {
+		xdg := filepath.Join(t.TempDir(), "xdg-config")
+		mkdirAll(t, filepath.Join(xdg, "opencode"))
+		t.Setenv("OPENCODE_HOME", "")
+		t.Setenv("XDG_CONFIG_HOME", xdg)
+
+		got := resolveOpenCodeDir()
+		want := filepath.Join(xdg, "opencode")
+		if got != want {
+			t.Fatalf("resolveOpenCodeDir() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("default when nothing exists", func(t *testing.T) {
+		t.Setenv("OPENCODE_HOME", "")
+		t.Setenv("XDG_CONFIG_HOME", "")
+
+		got := resolveOpenCodeDir()
+		want := filepath.Join(os.Getenv("HOME"), ".config", "opencode")
+		if got != want {
+			t.Fatalf("resolveOpenCodeDir() = %q, want %q", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Add OpenCode as a fourth install target alongside Codex, Claude, and Antigravity.

## Changes

- **New target `opencode`** in supported targets, usage string, flag description, and interactive prompt
- **`resolveOpenCodeDir()`** — searches for existing opencode config directory in priority order:
  1. `$OPENCODE_HOME` environment variable
  2. `$XDG_CONFIG_HOME/opencode`
  3. `~/.config/opencode`
  4. `~/.opencode`
  - Falls back to `~/.config/opencode` if none exist
- **`installOpenCodeCommands()`** — converts mothership skills to opencode commands:
  - `SKILL.md` in directories → `commands/<dir>.md` (e.g., `skills/commit/SKILL.md` → `commands/commit.md`)
  - Standalone `.md` in `skills/` root → `commands/<name>.md`
  - Nested skills preserved (e.g., `skills/obra/creating-plan/SKILL.md` → `commands/obra/creating-plan.md`)
  - `.system/` internal skills excluded
- **`verifyOpenCodeStructure()`** — post-install validation:
  - Confirms `commands/` directory exists
  - Verifies `.md` files are present
  - Checks no empty command files
- Standard dirs (`skills/`, `agents/`, `mothership-config/`) installed as-is alongside commands

## Test plan

- [x] All existing tests pass
- [x] New tests for `installOpenCodeCommands()` verify command generation from SKILL.md and standalone .md files
- [x] New tests for `verifyOpenCodeStructure()` cover valid, missing, and empty cases
- [x] New tests for `resolveOpenCodeDir()` validate env var priority and fallback behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)