### PR TITLE
feat: add pi as a supported host

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,19 @@
 # Mothership Local Agent Instructions
 
-This repository is an installable mothership package for Codex agents and skills.
+This repository is an installable mothership package for Codex, Claude, and Pi agents and skills.
 
 ## Entrypoint
 
 - Use the `mothership` skill as the manual entrypoint when orchestration behavior is desired.
 - Do not assume mothership should activate implicitly in mixed-skill environments.
+
+## Supported Hosts
+
+- **Claude Code** — uses built-in `Agent` tool for delegation
+- **Codex** — uses built-in `spawn_agent` for delegation
+- **Pi** — uses `mothership_spawn` extension tool (requires `skills/mothership/extensions/subagent.ts` installed under `~/.pi/agent/extensions/`)
+
+Install with `./install.sh --target <host>`. See `agents/registry.yaml` for per-host role mappings.
 
 ## Canonical Config
 

--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -19,6 +19,9 @@ roles:
     codex:
       tool: spawn_agent
       agent_type: explorer
+    pi:
+      tool: mothership_spawn
+      role: researcher
 
   coder:
     delegated: true
@@ -30,6 +33,9 @@ roles:
     codex:
       tool: spawn_agent
       agent_type: worker
+    pi:
+      tool: mothership_spawn
+      role: coder
 
   qa:
     delegated: true
@@ -41,6 +47,9 @@ roles:
     codex:
       tool: spawn_agent
       agent_type: explorer
+    pi:
+      tool: mothership_spawn
+      role: qa
 
   pr_monkey:
     delegated: true
@@ -52,3 +61,6 @@ roles:
     codex:
       tool: spawn_agent
       agent_type: default
+    pi:
+      tool: mothership_spawn
+      role: pr_monkey

--- a/skills/github-issue-management/SKILL.md
+++ b/skills/github-issue-management/SKILL.md
@@ -1,4 +1,9 @@
-# Skill: GitHub Issue Management
+---
+name: github-issue-management
+description: Define how mothership uses GitHub issues as durable workflow artifacts. Covers issue creation, linking, status tracking, and closure hygiene.
+---
+
+# GitHub Issue Management
 
 ## Purpose
 

--- a/skills/human-escalation/SKILL.md
+++ b/skills/human-escalation/SKILL.md
@@ -1,4 +1,9 @@
-# Skill: Human Escalation
+---
+name: human-escalation
+description: Define when and how the commander requests human input during the mothership workflow. Covers escalation triggers and escalation handling.
+---
+
+# Human Escalation
 
 ## Purpose
 

--- a/skills/mothership-setup/SKILL.md
+++ b/skills/mothership-setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mothership:setup
+name: mothership-setup
 description: Configure the mothership wiki for the current project. Run once per project to set up wiki directory structure, preferences, and default schema. Re-run to change wiki root location or other settings.
 ---
 

--- a/skills/mothership-setup/SKILL.md
+++ b/skills/mothership-setup/SKILL.md
@@ -17,7 +17,7 @@ description: Configure the mothership wiki for the current project. Run once per
 
 ## Implementation
 
-Executes `skills/mothership/scripts/wiki-setup.sh` from the repository root.
+Executes `../mothership/scripts/wiki-setup.sh` from the skill directory.
 
 ## Preferences
 

--- a/skills/mothership/SKILL.md
+++ b/skills/mothership/SKILL.md
@@ -25,6 +25,7 @@ Run this checklist immediately when `mothership` is invoked:
 5. Ensure `agents/registry.yaml` and `skills/mothership/subagent-protocol.md` are available.
 6. If preflight fails, record a `blocked` overlay or explicit fallback notes before continuing.
 7. If `.mothership/wiki.yaml` exists, read `projects/<name>/index.md` from the configured wiki root for project context.
+8. On pi: verify the `mothership_spawn` extension is available under `~/.pi/agent/extensions/`. If absent, delegation will not work — record a `blocked` overlay and continue without sub-agent spawning.
 
 ## Purpose
 
@@ -152,6 +153,11 @@ For Codex:
 - `researcher` should use `explorer`.
 - `coder` should use `worker`.
 - `qa` should use `explorer`.
+
+For Pi:
+
+- Use `mothership_spawn` with the `role` and `task` arguments declared in `agents/registry.yaml` under the `pi` host.
+- See `skills/mothership/subagent-protocol.md` for the full Pi delegation protocol.
 
 The commander may gather minimal routing context in `intake` and `planning`.
 After delegation starts, it must not continue the delegated work itself.

--- a/skills/mothership/extensions/subagent.ts
+++ b/skills/mothership/extensions/subagent.ts
@@ -1,0 +1,251 @@
+/**
+ * mothership_spawn - Sub-agent delegation tool for mothership on pi
+ *
+ * Spawns a pi subprocess to perform a delegated role (researcher, coder, qa,
+ * pr_monkey) using the role contract from agents/*.md.
+ */
+
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { Message } from "@mariozechner/pi-ai";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { Type } from "typebox";
+
+interface MothershipSpawnResult {
+	role: string;
+	output: string;
+	usage: {
+		inputTokens: number;
+		outputTokens: number;
+		costTotal: number;
+		turns: number;
+		model?: string;
+		stopReason?: string;
+	};
+	error?: string;
+}
+
+function getFinalOutput(messages: Message[]): string {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const msg = messages[i];
+		if (msg.role === "assistant") {
+			for (const part of msg.content) {
+				if (part.type === "text") return part.text;
+			}
+		}
+	}
+	return "";
+}
+
+async function runPiSubprocess(
+	contractPath: string,
+	task: string,
+	cwd: string,
+	signal: AbortSignal | undefined,
+	role: string,
+): Promise<MothershipSpawnResult> {
+	const result: MothershipSpawnResult = {
+		role,
+		output: "",
+		usage: { inputTokens: 0, outputTokens: 0, costTotal: 0, turns: 0 },
+	};
+
+	const args: string[] = ["--mode", "json", "-p", "--no-session"];
+	args.push("--append-system-prompt", contractPath);
+	args.push(`Task: ${task}`);
+
+	let wasAborted = false;
+	const messages: Message[] = [];
+
+	const exitCode = await new Promise<number>((resolve) => {
+		const proc = spawn("pi", args, {
+			cwd,
+			shell: false,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		let buffer = "";
+
+		const processLine = (line: string) => {
+			if (!line.trim()) return;
+			let event: any;
+			try {
+				event = JSON.parse(line);
+			} catch {
+				return;
+			}
+
+			if (event.type === "message_end" && event.message) {
+				const msg = event.message as Message;
+				messages.push(msg);
+
+				if (msg.role === "assistant") {
+					result.usage.turns++;
+					const usage = msg.usage as any;
+					if (usage) {
+						result.usage.inputTokens += usage.input || 0;
+						result.usage.outputTokens += usage.output || 0;
+						result.usage.costTotal += usage.cost?.total || 0;
+					}
+					if (!result.usage.model && (msg as any).model) result.usage.model = (msg as any).model;
+					if ((msg as any).stopReason) result.usage.stopReason = (msg as any).stopReason;
+				}
+			}
+
+			if (event.type === "tool_result_end" && event.message) {
+				messages.push(event.message as Message);
+			}
+		};
+
+		proc.stdout.on("data", (data) => {
+			buffer += data.toString();
+			const lines = buffer.split("\n");
+			buffer = lines.pop() || "";
+			for (const line of lines) processLine(line);
+		});
+
+		proc.on("close", (code) => {
+			if (buffer.trim()) processLine(buffer);
+			resolve(code ?? 0);
+		});
+
+		proc.on("error", () => {
+			resolve(1);
+		});
+
+		if (signal) {
+			const killProc = () => {
+				wasAborted = true;
+				proc.kill("SIGTERM");
+				setTimeout(() => {
+					if (!proc.killed) proc.kill("SIGKILL");
+				}, 5000);
+			};
+			if (signal.aborted) killProc();
+			else signal.addEventListener("abort", killProc, { once: true });
+		}
+	});
+
+	result.output = getFinalOutput(messages);
+
+	if (wasAborted) {
+		result.error = "Aborted by user";
+	} else if (exitCode !== 0) {
+		result.error = `Sub-process exited with code ${exitCode}`;
+	}
+
+	return result;
+}
+
+export default function (pi: ExtensionAPI) {
+	pi.registerTool({
+		name: "mothership_spawn",
+		label: "Mothership Spawn",
+		description:
+			"Delegate a task to a mothership role (researcher, coder, qa, pr_monkey) by spawning a new pi subprocess with the role contract. Use when mothership commander needs to delegate work to a sub-agent. Returns the sub-agent's final text output.",
+		parameters: Type.Object({
+			role: Type.String({
+				description:
+					"Mothership role to invoke: researcher, coder, qa, or pr_monkey. Determines which agent contract to use.",
+			}),
+			task: Type.String({
+				description:
+					"The task or question to delegate to the sub-agent. Should be a clear, self-contained request.",
+			}),
+			contract_file: Type.Optional(
+				Type.String({
+					description:
+						"Path to the role contract file (agents/<role>.md). If not provided, derived from the role name.",
+				}),
+			),
+			context: Type.Optional(
+				Type.String({
+					description:
+						"Additional context to pass to the sub-agent. Can include file paths, issue numbers, branch name, or other relevant details.",
+				}),
+			),
+			cwd: Type.Optional(
+				Type.String({
+					description: "Working directory for the subprocess. Defaults to the current pi working directory.",
+				}),
+			),
+		}),
+
+		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+			const role = params.role;
+			const task = params.task ?? "";
+			const contractFile =
+				params.contract_file ||
+				path.join(ctx.cwd, "agents", `${role}.md`);
+			const cwd = params.cwd ?? ctx.cwd;
+
+			const contextNote = params.context
+				? `\n\n---\n\nAdditional context:\n${params.context}\n\n---\n\n`
+				: "";
+
+			const enrichedTask = `${contextNote}${task}`;
+
+			if (!fs.existsSync(contractFile)) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `mothership_spawn failed: contract file not found: ${contractFile}`,
+						},
+					],
+					details: { role, error: "contract_not_found" },
+					isError: true,
+				};
+			}
+
+			try {
+				const result = await runPiSubprocess(
+					contractFile,
+					enrichedTask,
+					cwd,
+					signal,
+					role,
+				);
+
+				if (result.error) {
+					return {
+						content: [
+							{
+								type: "text",
+								text: `[${role}] ${result.error}${result.output ? `\n\nOutput:\n${result.output}` : ""}`,
+							},
+						],
+						details: { role, ...result.usage, error: result.error },
+						isError: true,
+					};
+				}
+
+				return {
+					content: [{ type: "text", text: result.output || "(no output)" }],
+					details: { role, ...result.usage },
+				};
+			} catch (err: any) {
+				return {
+					content: [{ type: "text", text: `mothership_spawn failed: ${err.message}` }],
+					details: { role, error: err.message },
+					isError: true,
+				};
+			}
+		},
+
+		renderCall(args, theme, _context) {
+			const roleName = args.role || "...";
+			const taskPreview = args.task
+				? args.task.length > 60
+					? args.task.slice(0, 60) + "..."
+					: args.task
+				: "...";
+			const label =
+				theme.fg("toolTitle", theme.bold("mothership_spawn ")) +
+				theme.fg("accent", roleName);
+			return new Text(label + "\n  " + theme.fg("dim", taskPreview), 0, 0);
+		},
+	});
+}

--- a/skills/mothership/extensions/subagent.ts
+++ b/skills/mothership/extensions/subagent.ts
@@ -13,6 +13,8 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "typebox";
 
+const VALID_ROLES = new Set(["researcher", "coder", "qa", "pr_monkey"]);
+
 interface MothershipSpawnResult {
 	role: string;
 	output: string;
@@ -57,6 +59,7 @@ async function runPiSubprocess(
 	args.push(`Task: ${task}`);
 
 	let wasAborted = false;
+	let stderrBuffer = "";
 	const messages: Message[] = [];
 
 	const exitCode = await new Promise<number>((resolve) => {
@@ -66,7 +69,7 @@ async function runPiSubprocess(
 			stdio: ["ignore", "pipe", "pipe"],
 		});
 
-		let buffer = "";
+		let stdoutBuffer = "";
 
 		const processLine = (line: string) => {
 			if (!line.trim()) return;
@@ -100,14 +103,18 @@ async function runPiSubprocess(
 		};
 
 		proc.stdout.on("data", (data) => {
-			buffer += data.toString();
-			const lines = buffer.split("\n");
-			buffer = lines.pop() || "";
+			stdoutBuffer += data.toString();
+			const lines = stdoutBuffer.split("\n");
+			stdoutBuffer = lines.pop() || "";
 			for (const line of lines) processLine(line);
 		});
 
+		proc.stderr.on("data", (data) => {
+			stderrBuffer += data.toString();
+		});
+
 		proc.on("close", (code) => {
-			if (buffer.trim()) processLine(buffer);
+			if (stdoutBuffer.trim()) processLine(stdoutBuffer);
 			resolve(code ?? 0);
 		});
 
@@ -116,15 +123,20 @@ async function runPiSubprocess(
 		});
 
 		if (signal) {
+			let sigkillTimer: ReturnType<typeof setTimeout> | undefined;
 			const killProc = () => {
 				wasAborted = true;
 				proc.kill("SIGTERM");
-				setTimeout(() => {
+				sigkillTimer = setTimeout(() => {
 					if (!proc.killed) proc.kill("SIGKILL");
 				}, 5000);
 			};
 			if (signal.aborted) killProc();
 			else signal.addEventListener("abort", killProc, { once: true });
+			// Clear the SIGKILL timer if the process exits normally before it fires
+			proc.on("close", () => {
+				if (sigkillTimer !== undefined) clearTimeout(sigkillTimer);
+			});
 		}
 	});
 
@@ -133,7 +145,8 @@ async function runPiSubprocess(
 	if (wasAborted) {
 		result.error = "Aborted by user";
 	} else if (exitCode !== 0) {
-		result.error = `Sub-process exited with code ${exitCode}`;
+		const stderr = stderrBuffer.trim();
+		result.error = `Sub-process exited with code ${exitCode}${stderr ? `: ${stderr}` : ""}`;
 	}
 
 	return result;
@@ -176,10 +189,25 @@ export default function (pi: ExtensionAPI) {
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 			const role = params.role;
 			const task = params.task ?? "";
+			const cwd = params.cwd ?? ctx.cwd;
+
+			// Validate role before any work
+			if (!VALID_ROLES.has(role)) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `mothership_spawn failed: unknown role "${role}". Valid roles: ${[...VALID_ROLES].join(", ")}`,
+						},
+					],
+					details: { role, error: "invalid_role" },
+					isError: true,
+				};
+			}
+
 			const contractFile =
 				params.contract_file ||
 				path.join(ctx.cwd, "agents", `${role}.md`);
-			const cwd = params.cwd ?? ctx.cwd;
 
 			const contextNote = params.context
 				? `\n\n---\n\nAdditional context:\n${params.context}\n\n---\n\n`

--- a/skills/mothership/subagent-protocol.md
+++ b/skills/mothership/subagent-protocol.md
@@ -150,6 +150,30 @@ Examples:
 When the delegated task depends on current thread context, fork the context.
 For coder roles, assign clear file or module ownership in the prompt.
 
+### Pi
+
+Pi has no built-in sub-agent spawning. Delegation requires the
+`mothership_spawn` extension tool to be loaded (installed under
+`~/.pi/agent/extensions/` alongside the mothership package).
+
+Use `mothership_spawn` with the arguments declared in `agents/registry.yaml`
+under the `pi` host for each role:
+
+- `role` — the mothership role to invoke (`researcher`, `coder`, `qa`, `pr_monkey`)
+- `task` — the task description or question for the sub-agent
+- `contract_file` — path to the role contract (`agents/<role>.md`)
+- `context` — any additional context to pass (issue, branch, files, etc.)
+
+The extension spawns a new `pi` subprocess for the delegated role and returns
+its output to commander. Commander waits for completion before transitioning.
+
+**Requirements:**
+- The `mothership_spawn` extension must be installed. See `skills/mothership/SKILL.md`
+  warmup checklist.
+- The subprocess inherits the pi working directory. File paths in the context
+  must be absolute or relative to the working directory.
+- The subprocess uses the same model unless overridden in the extension config.
+
 ## State Gates
 
 Before leaving a delegated state, commander must have evidence that:

--- a/skills/obra/creating-plan/SKILL.md
+++ b/skills/obra/creating-plan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: obra/creating-plan
+name: creating-plan
 description: Bundled dependency skill used by mothership research for structured plan creation.
 ---
 

--- a/skills/obra/superpowers/SKILL.md
+++ b/skills/obra/superpowers/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: obra/superpowers
+name: superpowers
 description: Bundled dependency skill used by mothership research for broad context gathering and option mapping.
 ---
 

--- a/skills/obra/systematical-debugging/SKILL.md
+++ b/skills/obra/systematical-debugging/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: obra/systematical-debugging
+name: systematical-debugging
 description: Bundled dependency skill used by mothership coding after QA feedback for structured debugging.
 ---
 

--- a/skills/parallelization-decision/SKILL.md
+++ b/skills/parallelization-decision/SKILL.md
@@ -1,4 +1,9 @@
-# Skill: Parallelization Decision
+---
+name: parallelization-decision
+description: Help commander decide whether work should be assigned to one coder agent or multiple coder agents in parallel.
+---
+
+# Parallelization Decision
 
 ## Purpose
 

--- a/skills/qa-review-loop/SKILL.md
+++ b/skills/qa-review-loop/SKILL.md
@@ -1,4 +1,9 @@
-# Skill: QA Review Loop
+---
+name: qa-review-loop
+description: Define the review cycle between coder agents, QA, and commander. Covers feedback routing, iteration, and approval criteria.
+---
+
+# QA Review Loop
 
 ## Purpose
 

--- a/skills/research-execution/SKILL.md
+++ b/skills/research-execution/SKILL.md
@@ -1,4 +1,9 @@
-# Skill: Research Execution
+---
+name: research-execution
+description: Define how research agents investigate a task before implementation planning. Covers hypothesis formation, context gathering, and structured output.
+---
+
+# Research Execution
 
 ## Purpose
 

--- a/skills/risk-assessment/SKILL.md
+++ b/skills/risk-assessment/SKILL.md
@@ -1,4 +1,9 @@
-# Skill: Risk Assessment
+---
+name: risk-assessment
+description: Give commander a structured way to classify task risk before choosing execution strategy. Covers risk dimensions and mitigation planning.
+---
+
+# Risk Assessment
 
 ## Purpose
 

--- a/skills/task-intake-and-decomposition/SKILL.md
+++ b/skills/task-intake-and-decomposition/SKILL.md
@@ -1,4 +1,9 @@
-# Skill: Task Intake and Decomposition
+---
+name: task-intake-and-decomposition
+description: Help commander turn an incoming human request into an actionable execution plan. Covers scoping, decomposition, and success criteria definition.
+---
+
+# Task Intake and Decomposition
 
 ## Purpose
 

--- a/skills/worktree-management/SKILL.md
+++ b/skills/worktree-management/SKILL.md
@@ -1,4 +1,9 @@
-# Skill: Worktree Management
+---
+name: worktree-management
+description: Define when and how isolated git worktrees are used for coder agents. Covers worktree creation, allocation, and cleanup.
+---
+
+# Worktree Management
 
 ## Purpose
 

--- a/tools/installer/main.go
+++ b/tools/installer/main.go
@@ -51,7 +51,7 @@ func parseFlags(args []string) (config, error) {
 	fs.SetOutput(io.Discard)
 
 	fs.StringVar(&cfg.RepoRoot, "repo-root", "", "repository root")
-	fs.StringVar(&cfg.Target, "target", "", "install target: codex, claude, antigravity, opencode")
+	fs.StringVar(&cfg.Target, "target", "", "install target: codex, claude, antigravity, opencode, pi")
 	fs.StringVar(&cfg.Mode, "mode", "", "install mode: symlink, copy")
 	fs.BoolVar(&cfg.Force, "force", false, "replace existing paths")
 
@@ -93,6 +93,7 @@ func promptMissing(cfg *config) error {
 					huh.NewOption("Claude", "claude"),
 					huh.NewOption("Antigravity", "antigravity"),
 					huh.NewOption("OpenCode", "opencode"),
+					huh.NewOption("Pi", "pi"),
 				).
 				Value(&cfg.Target),
 			huh.NewSelect[string]().
@@ -248,6 +249,8 @@ func targetRootFor(target string) string {
 		return filepath.Join(os.Getenv("HOME"), ".antigravity")
 	case "opencode":
 		return resolveOpenCodeDir()
+	case "pi":
+		return filepath.Join(os.Getenv("HOME"), ".pi", "agent")
 	default:
 		return ""
 	}
@@ -388,7 +391,7 @@ func copyFileWithMode(src, dst string, mode os.FileMode) error {
 }
 
 var supportedTargets = map[string]bool{
-	"codex": true, "claude": true, "antigravity": true, "opencode": true,
+	"codex": true, "claude": true, "antigravity": true, "opencode": true, "pi": true,
 }
 
 var supportedModes = map[string]bool{

--- a/tools/installer/main.go
+++ b/tools/installer/main.go
@@ -176,6 +176,15 @@ func install(cfg config) error {
 		fmt.Printf("  opencode commands: %d installed in %s\n", cmdCount, filepath.Join(targetRoot, "commands"))
 	}
 
+	if cfg.Target == "pi" {
+		extSrc := filepath.Join(cfg.RepoRoot, "skills", "mothership", "extensions", "subagent.ts")
+		extDst := filepath.Join(targetRoot, "extensions", "subagent.ts")
+		if err := copyFile(extSrc, extDst, cfg.Force); err != nil {
+			return err
+		}
+		fmt.Printf("  mothership_spawn extension: %s\n", extDst)
+	}
+
 	fmt.Printf("Installed Mothership to %s\n", targetRoot)
 	fmt.Printf("  target: %s\n", cfg.Target)
 	fmt.Printf("  mode: %s\n", cfg.Mode)


### PR DESCRIPTION
## Summary

Add pi as a supported host for mothership delegation. Includes the installer target, registry entries, protocol docs, the `mothership_spawn` extension, and skill frontmatter fixes so all skills load correctly on pi.

## Changes

| File | Change |
|------|--------|
| tools/installer/main.go | Add pi target (-> ~/.pi/agent/), interactive selector, supportedTargets map, post-install step to copy extension to ~/.pi/agent/extensions/ |
| agents/registry.yaml | Add pi host entry for researcher, coder, qa, pr_monkey — each maps to mothership_spawn with role name |
| skills/mothership/subagent-protocol.md | New Pi section: mothership_spawn tool interface and subprocess delegation model |
| skills/mothership/SKILL.md | Step 8 in warmup checklist (verify extension on pi), For Pi delegation entry |
| skills/mothership/extensions/subagent.ts | The mothership_spawn extension — spawns pi --mode json subprocess with role contract as system prompt, returns final text output |
| skills/github-issue-management/SKILL.md | Add required YAML frontmatter (name + description) |
| skills/human-escalation/SKILL.md | Add required YAML frontmatter |
| skills/parallelization-decision/SKILL.md | Add required YAML frontmatter |
| skills/qa-review-loop/SKILL.md | Add required YAML frontmatter |
| skills/research-execution/SKILL.md | Add required YAML frontmatter |
| skills/risk-assessment/SKILL.md | Add required YAML frontmatter |
| skills/task-intake-and-decomposition/SKILL.md | Add required YAML frontmatter |
| skills/worktree-management/SKILL.md | Add required YAML frontmatter |
| skills/mothership-setup/SKILL.md | Fix invalid name (mothership:setup -> mothership-setup), fix script path relative to install location |
| skills/obra/creating-plan/SKILL.md | Fix invalid name (obra/creating-plan -> creating-plan) |
| skills/obra/superpowers/SKILL.md | Fix invalid name (obra/superpowers -> superpowers) |
| skills/obra/systematical-debugging/SKILL.md | Fix invalid name (obra/systematical-debugging -> systematical-debugging) |
| AGENTS.md | Updated header to mention pi, new Supported Hosts section |

## How delegation works on pi

When mothership commander needs to delegate, it calls `mothership_spawn` with:

- `role` — researcher | coder | qa | pr_monkey
- `task` — the task description
- `context` — optional additional context (issue, branch, files)
- `contract_file` — optional (defaults to agents/<role>.md)

The extension spawns `pi --mode json -p --no-session --append-system-prompt <contract> <task>`, parses the JSON stream for final output, and returns it to commander.

## How to install

```bash
./install.sh --target pi --mode symlink
```

After install, run `/reload` in pi to pick up extensions and skills.

This installs to ~/.pi/agent/:
- skills/
- agents/
- mothership-config/
- .mothership/hub/
- extensions/subagent.ts <- the mothership_spawn tool
