### PR TITLE
refactor(installer): align pi install path with codex pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 
 # Windows NTFS alternate data stream metadata
 *:Zone.Identifier
+
+.mothership/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This repository is an installable mothership package for Codex, Claude, and Pi a
 
 - **Claude Code** — uses built-in `Agent` tool for delegation
 - **Codex** — uses built-in `spawn_agent` for delegation
-- **Pi** — uses `mothership_spawn` extension tool (requires `skills/mothership/extensions/subagent.ts` installed under `~/.pi/agent/extensions/`)
+- **Pi** — uses `mothership_spawn` extension tool (requires `skills/mothership/extensions/subagent.ts` installed under `~/.agents/extensions/`). Set `PI_HOME` env var to override the install root.
 
 Install with `./install.sh --target <host>`. See `agents/registry.yaml` for per-host role mappings.
 

--- a/tools/installer/main.go
+++ b/tools/installer/main.go
@@ -71,7 +71,7 @@ func parseFlags(args []string) (config, error) {
 }
 
 func usageErr(err error) error {
-	return fmt.Errorf("%w\n\nUsage: ./install.sh [--target codex|claude|antigravity|opencode] [--mode symlink|copy] [--force]", err)
+	return fmt.Errorf("%w\n\nUsage: ./install.sh [--target codex|claude|antigravity|opencode|pi] [--mode symlink|copy] [--force]", err)
 }
 
 func promptMissing(cfg *config) error {
@@ -259,7 +259,10 @@ func targetRootFor(target string) string {
 	case "opencode":
 		return resolveOpenCodeDir()
 	case "pi":
-		return filepath.Join(os.Getenv("HOME"), ".pi", "agent")
+		if root := os.Getenv("PI_HOME"); root != "" {
+			return root
+		}
+		return filepath.Join(os.Getenv("HOME"), ".agents")
 	default:
 		return ""
 	}


### PR DESCRIPTION
## Summary

Aligns the Pi install target path resolution with the Codex pattern — check  env var first, then fall back to .

## Changes

- **tools/installer/main.go**:  now mirrors Codex logic:
  - Check  env var first (for custom install roots)
  - Fall back to  (matching Codex/other agents convention)
  - Removed hardcoded  path
- **tools/installer/main.go**: Updated usage error message to include  in the flag docs
- **.gitignore**: Added  to ignore runtime artifacts

## Rationale

Pi also accepts skills/agents under  or , so  is not needed as a base install path. This makes the install target resolution consistent across all host agents.

## Validation

- Go build passes ()
- No functional change to other targets (codex, claude, antigravity, opencode)