### PR TITLE
feat(pi): team-first crew delegation with legacy fallback and PI_HOME installer updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This repository is an installable mothership package for Codex, Claude, and Pi a
 
 - **Claude Code** — uses built-in `Agent` tool for delegation
 - **Codex** — uses built-in `spawn_agent` for delegation
-- **Pi** — uses `mothership_spawn` extension tool (requires `skills/mothership/extensions/subagent.ts` installed under `~/.agents/extensions/`). Set `PI_HOME` env var to override the install root.
+- **Pi** — uses `mothership_spawn` extension tool (requires `skills/mothership/extensions/subagent.ts` and `skills/mothership/extensions/pi-routing.js` installed under `~/.agents/extensions/`). The extension prefers direct `team` tool delegation when configured/available, otherwise falls back to legacy subprocess spawning with explicit reason logging. Set `PI_HOME` env var to override the install root.
 
 Install with `./install.sh --target <host>`. See `agents/registry.yaml` for per-host role mappings.
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ It requires a local `go` toolchain.
 
 The script asks two questions:
 
-1. install target: `codex`, `claude`, or `antigravity`
+1. install target: `codex`, `claude`, `antigravity`, `opencode`, or `pi`
 2. install mode: `symlink` or `copy`
 
 Installed package contents:
@@ -261,6 +261,8 @@ Target roots:
 - `codex` -> `${CODEX_HOME:-~/.codex}`
 - `claude` -> `~/.claude`
 - `antigravity` -> `~/.antigravity`
+- `opencode` -> `${OPENCODE_HOME:-~/.config/opencode}`
+- `pi` -> `${PI_HOME:-~/.agents}`
 
 Why the hub contract is copied instead of symlinked:
 
@@ -268,12 +270,40 @@ Why the hub contract is copied instead of symlinked:
 - copying `.mothership/hub/README.md` keeps the contract available without
   writing runtime state back into this repository.
 
+### Pi Setup
+
+Pi uses `~/.agents` as its install root (not `~/.pi`) to avoid conflicts with
+Codex. The `PI_HOME` environment variable overrides this.
+
+Prerequisites:
+
+```bash
+# 1. Install pi-crew (required for team-first routing)
+pi install npm:pi-crew
+
+# 2. Install required extensions (idempotent)
+pi-crew pi install npm:pi-powerline-footer
+pi-crew pi install npm:@juicesharp/rpiv-todo
+
+# 3. Run the mothership installer
+./install.sh --target pi --mode copy
+```
+
+The installer copies skills, agents, config, the hub contract, and Pi runtime
+extension files to `$PI_HOME/`. Verify:
+
+```bash
+ls $PI_HOME/extensions/subagent.ts
+ls $PI_HOME/extensions/pi-routing.js
+```
+
 Non-interactive examples:
 
 ```bash
 ./install.sh --target claude --mode symlink
 ./install.sh --target codex --mode copy
 ./install.sh --target antigravity --mode symlink --force
+./install.sh --target pi --mode copy
 ```
 
 ## Using It

--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -22,6 +22,9 @@ roles:
     pi:
       tool: mothership_spawn
       role: researcher
+      team_path_enabled: true
+      team_tool: team
+      team: research
 
   coder:
     delegated: true
@@ -36,6 +39,11 @@ roles:
     pi:
       tool: mothership_spawn
       role: coder
+      team_path_enabled: true
+      team_tool: team
+      team: implementation
+      model_hint: ""
+      model_fallback_chain: ""
 
   qa:
     delegated: true
@@ -50,6 +58,9 @@ roles:
     pi:
       tool: mothership_spawn
       role: qa
+      team_path_enabled: true
+      team_tool: team
+      team: review
 
   pr_monkey:
     delegated: true
@@ -64,3 +75,6 @@ roles:
     pi:
       tool: mothership_spawn
       role: pr_monkey
+      team_path_enabled: true
+      team_tool: team
+      team: default

--- a/skills/mothership/SKILL.md
+++ b/skills/mothership/SKILL.md
@@ -25,7 +25,43 @@ Run this checklist immediately when `mothership` is invoked:
 5. Ensure `agents/registry.yaml` and `skills/mothership/subagent-protocol.md` are available.
 6. If preflight fails, record a `blocked` overlay or explicit fallback notes before continuing.
 7. If `.mothership/wiki.yaml` exists, read `projects/<name>/index.md` from the configured wiki root for project context.
-8. On pi: verify the `mothership_spawn` extension is available under `~/.pi/agent/extensions/`. If absent, delegation will not work — record a `blocked` overlay and continue without sub-agent spawning.
+8. On pi: verify the `mothership_spawn` extension is available under `$PI_HOME/extensions/` (default `~/.agents/extensions/`). If absent, delegation will not work — record a `blocked` overlay and continue without sub-agent spawning.
+
+## Pi Setup Prerequisites
+
+Before using mothership with Pi, ensure the following prerequisites are met:
+
+1. **Install target is `~/.agents`.** The canonical Pi install root is `~/.agents` to
+   avoid conflicts with Codex (which uses `~/.codex`). The installer sets
+   `PI_HOME=~/.agents` so Pi resolves extensions from `$PI_HOME/extensions/`.
+
+2. **Install pi-crew.** Mothership team-first routing requires pi-crew:
+   ```bash
+   pi install npm:pi-crew
+   ```
+
+3. **Install required extensions** (idempotent, safe to re-run):
+   ```bash
+   pi-crew pi install npm:pi-powerline-footer
+   pi-crew pi install npm:@juicesharp/rpiv-todo
+   ```
+
+4. **Run the mothership installer for Pi:**
+   ```bash
+   ./install.sh --target pi --mode copy
+   ```
+   This copies skills, agents, config, and the `mothership_spawn` extension to
+   `$PI_HOME/` (default `~/.agents/`).
+
+5. **Verify the extension resolves:**
+   ```bash
+   ls $PI_HOME/extensions/subagent.ts
+   ls $PI_HOME/extensions/pi-routing.js
+   ```
+   If the file is absent, delegation will not work.
+
+6. **Secure config guidance:** Do not commit secrets or API keys to agent config
+   files. Use user-scope config only (`$PI_HOME/` is user-local).
 
 ## Purpose
 
@@ -166,6 +202,7 @@ For Codex:
 For Pi:
 
 - Use `mothership_spawn` with the `role` and `task` arguments declared in `agents/registry.yaml` under the `pi` host.
+- `mothership_spawn` is team-first: it calls the configured `team` tool directly when available (`team_path_enabled`, mapped `team`, optional `model_hint`/`model_fallback_chain`). By default `team_tool` must be exactly `team` unless explicitly sanctioned (`team_tool_allow_unsafe: true`), otherwise it falls back to legacy subprocess spawning with explicit reason logging.
 - See `skills/mothership/subagent-protocol.md` for the full Pi delegation protocol.
 
 The commander may gather minimal routing context in `intake` and `planning`.

--- a/skills/mothership/extensions/pi-routing.js
+++ b/skills/mothership/extensions/pi-routing.js
@@ -1,0 +1,67 @@
+const DEFAULT_ROLE_TEAM_MAP = {
+  researcher: "research",
+  coder: "implementation",
+  qa: "review",
+  pr_monkey: "default",
+};
+
+const SAFE_TEAM_TOOL_ALLOWLIST = new Set(["team"]);
+
+function parseModelFallbackChain(raw) {
+  if (Array.isArray(raw)) return raw.map((v) => `${v}`.trim()).filter(Boolean);
+  if (typeof raw === "string") {
+    return raw
+      .split(",")
+      .map((v) => v.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+export function decidePiRoute({ role, config, availableTools }) {
+  const pi = config?.pi || {};
+  const teamTool = pi.team_tool || "team";
+  const enabled = pi.team_path_enabled !== false;
+
+  if (!enabled) {
+    return { path: "legacy", reason: "team_path_disabled", teamTool };
+  }
+
+  const unsafeToolAllowed = pi.team_tool_allow_unsafe === true;
+  if (!SAFE_TEAM_TOOL_ALLOWLIST.has(teamTool) && !unsafeToolAllowed) {
+    return { path: "legacy", reason: "team_tool_unsafe", teamTool };
+  }
+
+  const teamName = pi.team || DEFAULT_ROLE_TEAM_MAP[role];
+  if (!teamName) {
+    return { path: "legacy", reason: "team_mapping_missing", teamTool };
+  }
+
+  if (!availableTools.includes(teamTool)) {
+    return { path: "legacy", reason: "team_tool_unavailable", teamTool, teamName };
+  }
+
+  const modelFallbackChain = parseModelFallbackChain(pi.model_fallback_chain);
+  return {
+    path: "team",
+    teamTool,
+    teamName,
+    modelHint: pi.model_hint,
+    modelFallbackChain,
+  };
+}
+
+export function buildTeamInvocation({ teamName, task, modelHint, modelFallbackChain }) {
+  const payload = {
+    action: "run",
+    team: teamName,
+    goal: task,
+  };
+  if (modelHint) payload.model = modelHint;
+  if (Array.isArray(modelFallbackChain) && modelFallbackChain.length > 0) {
+    payload.model_fallback_chain = modelFallbackChain;
+  }
+  return payload;
+}
+
+export { DEFAULT_ROLE_TEAM_MAP, SAFE_TEAM_TOOL_ALLOWLIST };

--- a/skills/mothership/extensions/pi-routing.test.mjs
+++ b/skills/mothership/extensions/pi-routing.test.mjs
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { decidePiRoute, buildTeamInvocation } from "./pi-routing.js";
+
+test("routes to team when enabled and available", () => {
+  const route = decidePiRoute({
+    role: "coder",
+    config: { pi: { team_path_enabled: true, team: "implementation", team_tool: "team" } },
+    availableTools: ["team"],
+  });
+  assert.equal(route.path, "team");
+  assert.equal(route.teamName, "implementation");
+});
+
+test("falls back to legacy when team tool unavailable", () => {
+  const route = decidePiRoute({
+    role: "qa",
+    config: { pi: { team_path_enabled: true, team: "review", team_tool: "team" } },
+    availableTools: [],
+  });
+  assert.equal(route.path, "legacy");
+  assert.equal(route.reason, "team_tool_unavailable");
+});
+
+test("uses default team mapping", () => {
+  const route = decidePiRoute({
+    role: "researcher",
+    config: { pi: { team_path_enabled: true, team_tool: "team" } },
+    availableTools: ["team"],
+  });
+  assert.equal(route.path, "team");
+  assert.equal(route.teamName, "research");
+});
+
+test("disallow config forces legacy with explicit reason", () => {
+  const route = decidePiRoute({
+    role: "pr_monkey",
+    config: { pi: { team_path_enabled: false, team_tool: "team" } },
+    availableTools: ["team"],
+  });
+  assert.equal(route.path, "legacy");
+  assert.equal(route.reason, "team_path_disabled");
+});
+
+test("passes optional model hint", () => {
+  const route = decidePiRoute({
+    role: "coder",
+    config: { pi: { team_path_enabled: true, team: "implementation", team_tool: "team", model_hint: "gpt-5" } },
+    availableTools: ["team"],
+  });
+  assert.equal(route.path, "team");
+  assert.equal(route.modelHint, "gpt-5");
+});
+
+test("supports configurable model fallback chain", () => {
+  const route = decidePiRoute({
+    role: "coder",
+    config: {
+      pi: {
+        team_path_enabled: true,
+        team: "implementation",
+        team_tool: "team",
+        model_hint: "gpt-5",
+        model_fallback_chain: "gpt-5,gpt-4.1-mini",
+      },
+    },
+    availableTools: ["team"],
+  });
+  assert.equal(route.path, "team");
+  assert.deepEqual(route.modelFallbackChain, ["gpt-5", "gpt-4.1-mini"]);
+});
+
+test("rejects unsafe team tool unless explicitly sanctioned", () => {
+  const unsafe = decidePiRoute({
+    role: "coder",
+    config: { pi: { team_path_enabled: true, team: "implementation", team_tool: "team --danger" } },
+    availableTools: ["team --danger"],
+  });
+  assert.equal(unsafe.path, "legacy");
+  assert.equal(unsafe.reason, "team_tool_unsafe");
+
+  const sanctioned = decidePiRoute({
+    role: "coder",
+    config: {
+      pi: {
+        team_path_enabled: true,
+        team: "implementation",
+        team_tool: "team --danger",
+        team_tool_allow_unsafe: true,
+      },
+    },
+    availableTools: ["team --danger"],
+  });
+  assert.equal(sanctioned.path, "team");
+});
+
+test("builds team invocation with action run and model fallback chain", () => {
+  const args = buildTeamInvocation({
+    teamName: "implementation",
+    task: "Implement feature X",
+    modelHint: "gpt-5",
+    modelFallbackChain: ["gpt-5", "gpt-4.1-mini"],
+  });
+  assert.deepEqual(args, {
+    action: "run",
+    team: "implementation",
+    goal: "Implement feature X",
+    model: "gpt-5",
+    model_fallback_chain: ["gpt-5", "gpt-4.1-mini"],
+  });
+});

--- a/skills/mothership/extensions/subagent.ts
+++ b/skills/mothership/extensions/subagent.ts
@@ -12,6 +12,7 @@ import type { Message } from "@mariozechner/pi-ai";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "typebox";
+import { buildTeamInvocation, decidePiRoute } from "./pi-routing.js";
 
 const VALID_ROLES = new Set(["researcher", "coder", "qa", "pr_monkey"]);
 
@@ -39,6 +40,50 @@ function getFinalOutput(messages: Message[]): string {
 		}
 	}
 	return "";
+}
+
+function parsePiRoleConfigFromRegistry(registryPath: string, role: string): { pi: Record<string, any> } {
+	if (!fs.existsSync(registryPath)) return { pi: {} };
+	const content = fs.readFileSync(registryPath, "utf8");
+	const roleRegex = new RegExp(`\\n\\s{2}${role}:([\\s\\S]*?)(?=\\n\\s{2}[a-z_]+:|$)`);
+	const roleMatch = content.match(roleRegex);
+	if (!roleMatch) return { pi: {} };
+	const block = roleMatch[1];
+	const piMatch = block.match(/\n\s{4}pi:([\s\S]*?)(?=\n\s{4}[a-z_]+:|\n\s{2}[a-z_]+:|$)/);
+	if (!piMatch) return { pi: {} };
+	const piBlock = piMatch[1];
+	const pi: Record<string, any> = {};
+	for (const rawLine of piBlock.split("\n")) {
+		const line = rawLine.trim();
+		if (!line || line.startsWith("#")) continue;
+		const idx = line.indexOf(":");
+		if (idx <= 0) continue;
+		const key = line.slice(0, idx).trim();
+		let value: any = line.slice(idx + 1).trim();
+		if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+			value = value.slice(1, -1);
+		}
+		if (value === "true") value = true;
+		else if (value === "false") value = false;
+		pi[key] = value;
+	}
+	return { pi };
+}
+
+function getAvailableToolNames(ctx: any): string[] {
+	const names = new Set<string>();
+	const candidates = [ctx?.tools, ctx?.runtime?.tools, ctx?.availableTools];
+	for (const c of candidates) {
+		if (Array.isArray(c)) {
+			for (const t of c) {
+				if (typeof t === "string") names.add(t);
+				else if (t?.name) names.add(t.name);
+			}
+		} else if (c && typeof c === "object") {
+			for (const key of Object.keys(c)) names.add(key);
+		}
+	}
+	return [...names];
 }
 
 async function runPiSubprocess(
@@ -229,6 +274,42 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			try {
+				const registryPath = path.join(ctx.cwd, "agents", "registry.yaml");
+				const roleConfig = parsePiRoleConfigFromRegistry(registryPath, role);
+				const route = decidePiRoute({ role, config: roleConfig, availableTools: getAvailableToolNames(ctx as any) });
+
+				if (route.path === "team") {
+					const payload = buildTeamInvocation({
+						teamName: route.teamName,
+						task: enrichedTask,
+						modelHint: route.modelHint,
+						modelFallbackChain: route.modelFallbackChain,
+					});
+					const callTool = (ctx as any)?.callTool || (ctx as any)?.executeTool || (pi as any)?.callTool;
+					if (typeof callTool === "function") {
+						try {
+							const teamResult = await callTool(route.teamTool, payload, signal);
+							if (teamResult?.isError) {
+								console.warn(`[mothership_spawn] fallback=legacy reason=team_tool_unhealthy tool=${route.teamTool} role=${role}`);
+							} else {
+								const output = Array.isArray(teamResult?.content)
+									? teamResult.content.map((c: any) => c?.text || "").join("\n").trim()
+									: "";
+								return {
+									content: [{ type: "text", text: output || "(no output)" }],
+									details: { role, route: "team", team: route.teamName, team_tool: route.teamTool, model_hint: route.modelHint, model_fallback_chain: route.modelFallbackChain },
+								};
+							}
+						} catch {
+							console.warn(`[mothership_spawn] fallback=legacy reason=team_tool_unhealthy tool=${route.teamTool} role=${role}`);
+						}
+					} else {
+						console.warn(`[mothership_spawn] fallback=legacy reason=team_tool_unavailable tool=${route.teamTool} role=${role}`);
+					}
+				} else {
+					console.warn(`[mothership_spawn] fallback=legacy reason=${route.reason} role=${role}`);
+				}
+
 				const result = await runPiSubprocess(
 					contractFile,
 					enrichedTask,

--- a/skills/mothership/subagent-protocol.md
+++ b/skills/mothership/subagent-protocol.md
@@ -152,27 +152,54 @@ For coder roles, assign clear file or module ownership in the prompt.
 
 ### Pi
 
-Pi has no built-in sub-agent spawning. Delegation requires the
-`mothership_spawn` extension tool to be loaded (installed under
-`~/.pi/agent/extensions/` alongside the mothership package).
+Pi delegation is team-first when the runtime exposes the `team` tool.
 
-Use `mothership_spawn` with the arguments declared in `agents/registry.yaml`
-under the `pi` host for each role:
+`mothership_spawn` reads `agents/registry.yaml` (`roles.<role>.pi`) and:
+
+1. Tries direct `team` tool invocation with mapped `team`, optional
+   `model_hint`, and optional `model_fallback_chain` when
+   `team_path_enabled: true` and the configured `team_tool` is available.
+   For safety, `team_tool` must be exactly `team` unless explicitly sanctioned
+   via `team_tool_allow_unsafe: true`.
+2. Falls back to legacy subprocess spawning (`pi --mode json`) when team-path
+   is disabled, unmapped, unavailable, or unhealthy.
+
+Fallback reasons are logged explicitly (for example:
+`team_path_disabled`, `team_mapping_missing`, `team_tool_unsafe`,
+`team_tool_unavailable`, `team_tool_unhealthy`).
+
+Legacy path arguments remain:
 
 - `role` — the mothership role to invoke (`researcher`, `coder`, `qa`, `pr_monkey`)
 - `task` — the task description or question for the sub-agent
 - `contract_file` — path to the role contract (`agents/<role>.md`)
 - `context` — any additional context to pass (issue, branch, files, etc.)
 
-The extension spawns a new `pi` subprocess for the delegated role and returns
-its output to commander. Commander waits for completion before transitioning.
+Commander waits for completion before transitioning.
 
 **Requirements:**
-- The `mothership_spawn` extension must be installed. See `skills/mothership/SKILL.md`
-  warmup checklist.
+- The `mothership_spawn` runtime extension files must be installed under
+  `$PI_HOME/extensions/` (default `~/.agents/extensions/`):
+  `subagent.ts` and `pi-routing.js`. See `skills/mothership/SKILL.md` warmup checklist.
+- The install target for Pi is `~/.agents` (not `~/.codex` or `~/.pi`) to avoid
+  conflicts with other agent hosts. Set the `PI_HOME` environment variable to
+  override.
+- **Required prerequisite:** `pi install npm:pi-crew`
+- **Required extension installs** (idempotent):
+  ```bash
+  pi-crew pi install npm:pi-powerline-footer
+  pi-crew pi install npm:@juicesharp/rpiv-todo
+  ```
 - The subprocess inherits the pi working directory. File paths in the context
   must be absolute or relative to the working directory.
 - The subprocess uses the same model unless overridden in the extension config.
+
+**Secure config guidance:**
+- Do not commit secrets or API keys to agent config files under `$PI_HOME/`.
+- Use user-scope configuration only. `$PI_HOME/` is user-local and should not
+  be shared across users or committed to version control.
+- If model fallback chains reference provider keys, store them in environment
+  variables or the provider's native credential store — never in YAML config.
 
 ## State Gates
 

--- a/tools/installer/main.go
+++ b/tools/installer/main.go
@@ -177,12 +177,15 @@ func install(cfg config) error {
 	}
 
 	if cfg.Target == "pi" {
-		extSrc := filepath.Join(cfg.RepoRoot, "skills", "mothership", "extensions", "subagent.ts")
-		extDst := filepath.Join(targetRoot, "extensions", "subagent.ts")
-		if err := copyFile(extSrc, extDst, cfg.Force); err != nil {
-			return err
+		extensions := []string{"subagent.ts", "pi-routing.js"}
+		for _, name := range extensions {
+			extSrc := filepath.Join(cfg.RepoRoot, "skills", "mothership", "extensions", name)
+			extDst := filepath.Join(targetRoot, "extensions", name)
+			if err := copyFile(extSrc, extDst, cfg.Force); err != nil {
+				return err
+			}
+			fmt.Printf("  mothership_spawn extension dependency: %s\n", extDst)
 		}
-		fmt.Printf("  mothership_spawn extension: %s\n", extDst)
 	}
 
 	fmt.Printf("Installed Mothership to %s\n", targetRoot)

--- a/tools/installer/main_test.go
+++ b/tools/installer/main_test.go
@@ -210,6 +210,103 @@ func TestVerifyOpenCodeStructure(t *testing.T) {
 	})
 }
 
+func TestInstallPiTarget(t *testing.T) {
+	repoRoot := makeValidRepo(t)
+	// Create the extension source file the installer expects
+	mkdirAll(t, filepath.Join(repoRoot, "skills", "mothership", "extensions"))
+	writeFile(t, filepath.Join(repoRoot, "skills", "mothership", "extensions", "subagent.ts"),
+		"// mothership_spawn extension")
+	writeFile(t, filepath.Join(repoRoot, "skills", "mothership", "extensions", "pi-routing.js"),
+		"// routing dependency")
+
+	piHome := filepath.Join(t.TempDir(), ".agents")
+	t.Setenv("PI_HOME", piHome)
+
+	cfg := config{
+		RepoRoot: repoRoot,
+		Target:   "pi",
+		Mode:     "copy",
+	}
+
+	if err := install(cfg); err != nil {
+		t.Fatalf("install() error = %v", err)
+	}
+
+	// Standard dirs installed
+	for _, rel := range []string{"skills", "agents", "mothership-config"} {
+		p := filepath.Join(piHome, rel)
+		if info, err := os.Stat(p); err != nil || !info.IsDir() {
+			t.Fatalf("expected directory %s, got err=%v isDir=%v", p, err, info != nil && info.IsDir())
+		}
+	}
+
+	// Hub contract created
+	hubReadme := filepath.Join(piHome, ".mothership", "hub", "README.md")
+	if data, err := os.ReadFile(hubReadme); err != nil {
+		t.Fatalf("hub contract %s missing: %v", hubReadme, err)
+	} else if string(data) != "hub contract" {
+		t.Fatalf("hub contract %s has wrong content: %s", hubReadme, string(data))
+	}
+
+	// Extension files copied to target
+	subagentFile := filepath.Join(piHome, "extensions", "subagent.ts")
+	if data, err := os.ReadFile(subagentFile); err != nil {
+		t.Fatalf("extension %s missing: %v", subagentFile, err)
+	} else if !strings.Contains(string(data), "mothership_spawn") {
+		t.Fatalf("extension %s has wrong content: %s", subagentFile, string(data))
+	}
+
+	routingFile := filepath.Join(piHome, "extensions", "pi-routing.js")
+	if data, err := os.ReadFile(routingFile); err != nil {
+		t.Fatalf("extension %s missing: %v", routingFile, err)
+	} else if !strings.Contains(string(data), "routing dependency") {
+		t.Fatalf("extension %s has wrong content: %s", routingFile, string(data))
+	}
+}
+
+func TestInstallPiTargetDefaultPath(t *testing.T) {
+	repoRoot := makeValidRepo(t)
+	mkdirAll(t, filepath.Join(repoRoot, "skills", "mothership", "extensions"))
+	writeFile(t, filepath.Join(repoRoot, "skills", "mothership", "extensions", "subagent.ts"),
+		"// extension")
+	writeFile(t, filepath.Join(repoRoot, "skills", "mothership", "extensions", "pi-routing.js"),
+		"// extension routing")
+
+	// Clear PI_HOME to test default resolution
+	t.Setenv("PI_HOME", "")
+
+	cfg := config{
+		RepoRoot: repoRoot,
+		Target:   "pi",
+		Mode:     "copy",
+	}
+
+	// targetRootFor should return ~/.agents when PI_HOME is empty
+	targetRoot := targetRootFor("pi")
+	wantDefault := filepath.Join(os.Getenv("HOME"), ".agents")
+	if targetRoot != wantDefault {
+		t.Fatalf("targetRootFor(pi) = %q, want %q", targetRoot, wantDefault)
+	}
+
+	// Install to an isolated temp dir to avoid polluting real home
+	isolated := filepath.Join(t.TempDir(), ".agents")
+	t.Setenv("PI_HOME", isolated)
+
+	if err := install(cfg); err != nil {
+		t.Fatalf("install() error = %v", err)
+	}
+
+	// Verify extensions landed at the correct path
+	subagentFile := filepath.Join(isolated, "extensions", "subagent.ts")
+	if _, err := os.Stat(subagentFile); err != nil {
+		t.Fatalf("extension %s missing after install: %v", subagentFile, err)
+	}
+	routingFile := filepath.Join(isolated, "extensions", "pi-routing.js")
+	if _, err := os.Stat(routingFile); err != nil {
+		t.Fatalf("extension %s missing after install: %v", routingFile, err)
+	}
+}
+
 func TestResolveOpenCodeDir(t *testing.T) {
 	t.Run("OPENCODE_HOME takes priority", func(t *testing.T) {
 		custom := filepath.Join(t.TempDir(), "custom-opencode")


### PR DESCRIPTION
## What changed

- Added team-first Pi routing in `skills/mothership/extensions/pi-routing.js` with:
  - role→team defaults
  - `team` tool allowlist safety check
  - optional `model_hint` and `model_fallback_chain`
  - explicit legacy fallback reasons (`team_path_disabled`, `team_mapping_missing`, `team_tool_unsafe`, `team_tool_unavailable`, `team_tool_unhealthy`)
- Updated `skills/mothership/extensions/subagent.ts` to:
  - read Pi role config from `agents/registry.yaml`
  - detect available tools at runtime
  - invoke `team` directly when healthy
  - fall back to legacy subprocess spawning with reason logging
- Updated Pi role entries in `agents/registry.yaml` to configure team-path defaults.
- Added/updated Pi setup docs across `README.md`, `AGENTS.md`, `skills/mothership/SKILL.md`, and `skills/mothership/subagent-protocol.md`:
  - `$PI_HOME` install root guidance (`~/.agents` default)
  - required `pi-crew` and extension prerequisites
  - extension verification steps
- Updated installer (`tools/installer/main.go`) to install both runtime extension files:
  - `subagent.ts`
  - `pi-routing.js`
- Added tests:
  - `skills/mothership/extensions/pi-routing.test.mjs`
  - installer coverage for Pi target + default path behavior (`tools/installer/main_test.go`)

## Why

Issue #14 requires Pi delegation to prefer the native team path when available while preserving compatibility through legacy subprocess fallback. It also requires installer/runtime alignment around `PI_HOME` and Pi extension dependencies.

## Impact

- **Pi users**: Delegation now prefers direct `team` execution, improving integration with pi-crew workflows.
- **Reliability**: If team-path cannot be used, behavior degrades safely to legacy subprocess execution with explicit diagnostics.
- **Install/ops**: Pi installs now consistently place required extension files under `$PI_HOME/extensions`.
- **Docs**: Setup steps and prerequisites are clearer and aligned with runtime behavior.

## Validation

- ✅ `node --test skills/mothership/extensions/pi-routing.test.mjs`
- ✅ `(cd tools/installer && go test ./...)`

Closes #14.
