### PR TITLE
feat: add documentation sync automation

### DIFF
--- a/.github/workflows/documentation-sync.yml
+++ b/.github/workflows/documentation-sync.yml
@@ -1,0 +1,126 @@
+name: Documentation Sync
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to document
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-documentation:
+    name: Sync feature documentation
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve pull request metadata
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            pr_number="$INPUT_PR_NUMBER"
+          else
+            pr_number="$EVENT_PR_NUMBER"
+          fi
+
+          gh pr view "$pr_number" \
+            --json number,title,url,body,mergeCommit,mergedAt,files \
+            > pr.json
+
+          jq -r '.files[].path' pr.json > changed-paths.txt
+          jq -r '.body // ""' pr.json > pr-body.md
+          {
+            echo "number=$(jq -r '.number' pr.json)"
+            echo "title=$(jq -r '.title' pr.json)"
+            echo "url=$(jq -r '.url' pr.json)"
+            echo "merge_sha=$(jq -r '.mergeCommit.oid // empty' pr.json)"
+            echo "merged_at=$(jq -r '.mergedAt // empty' pr.json)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate documentation updates
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+          MERGE_SHA: ${{ steps.pr.outputs.merge_sha }}
+          MERGED_AT: ${{ steps.pr.outputs.merged_at }}
+        run: |
+          set -euo pipefail
+
+          args=(
+            --pr-number "$PR_NUMBER"
+            --pr-title "$PR_TITLE"
+            --pr-url "$PR_URL"
+            --merge-sha "$MERGE_SHA"
+            --merged-at "$MERGED_AT"
+          )
+
+          while IFS= read -r path; do
+            [ -n "$path" ] && args+=(--changed-path "$path")
+          done < changed-paths.txt
+
+          python3 scripts/sync_documentation.py "${args[@]}" --pr-body-file pr-body.md
+
+      - name: Stop if documentation is already synced
+        id: diff
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- docs/features.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open documentation sync pull request
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+        run: |
+          set -euo pipefail
+
+          branch="docs/sync-pr-${PR_NUMBER}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add docs/features.md
+          git commit -m "docs: sync feature documentation for #${PR_NUMBER}"
+          git push --force-with-lease origin "$branch"
+
+          if gh pr view "$branch" --json number >/dev/null 2>&1; then
+            gh pr edit "$branch" \
+              --title "docs: sync feature documentation for #${PR_NUMBER}" \
+              --body "Updates feature changelog, feature description, and usage help for merged PR #${PR_NUMBER}: ${PR_TITLE}."
+          else
+            gh pr create \
+              --base main \
+              --head "$branch" \
+              --title "docs: sync feature documentation for #${PR_NUMBER}" \
+              --body "Updates feature changelog, feature description, and usage help for merged PR #${PR_NUMBER}: ${PR_TITLE}."
+          fi

--- a/README.md
+++ b/README.md
@@ -317,12 +317,32 @@ are silently skipped.
 Required auxiliary skills are listed in
 [mothership-config/skill-dependencies.md](mothership-config/skill-dependencies.md).
 
+## Documentation Sync
+
+Feature-bearing pull requests that merge to `main` are followed by an automated
+documentation sync check. The workflow in
+[`.github/workflows/documentation-sync.yml`](.github/workflows/documentation-sync.yml)
+runs [`scripts/sync_documentation.py`](scripts/sync_documentation.py), updates
+[`docs/features.md`](docs/features.md) when feature changelogs, descriptions,
+or usage help are missing, and opens a follow-up documentation pull request for
+maintainer review.
+
+Feature PRs should include `Feature changelog`, `Feature description`, and
+`Usage help` sections in their PR body so the generated documentation PR is
+complete instead of placeholder-based. See
+[`docs/documentation-sync.md`](docs/documentation-sync.md) for the exact
+workflow and supported PR body markers.
+
 ## Repository Layout
 
 - `agents/`: role contracts for commander, researcher, coder, QA, and PR monkey
 - `agents/registry.yaml`: host-specific mapping from mothership roles to the sub-agent tool flavor
 - `mothership-config/`: canonical workflow, roles registry, skill dependencies, and wiki schema
 - `skills/`: installable skills plus supporting workflow guidance
+- `docs/features.md`: generated and reviewed feature changelog, descriptions, and usage help
+- `docs/documentation-sync.md`: documentation sync workflow and PR body authoring guide
+- `scripts/sync_documentation.py`: deterministic documentation sync generator used by GitHub Actions
+- `.github/workflows/documentation-sync.yml`: post-merge workflow that opens documentation follow-up PRs
 - `skills/mothership/wiki-protocol.md`: wiki role permissions, quality gate, and promotion process
 - `skills/mothership-setup/SKILL.md`: wiki setup skill (invoked as `/mothership:setup`)
 - `skills/mothership/scripts/wiki-setup.sh`: wiki initialization script

--- a/docs/documentation-sync.md
+++ b/docs/documentation-sync.md
@@ -1,0 +1,74 @@
+# Documentation Sync Automation
+
+Mothership keeps feature documentation current with a follow-up pull request
+after each feature-bearing PR is merged to `main`.
+
+## When the workflow runs
+
+The documentation sync workflow runs when a pull request targeting `main` is
+closed and merged. It skips documentation-only and automation-only changes.
+Feature-bearing changes include files under:
+
+- `agents/`
+- `mothership-config/`
+- `skills/`
+- `tools/`
+- `install.sh`
+
+Maintainers can also run the workflow manually with `workflow_dispatch` by
+providing a PR number.
+
+## What the workflow updates
+
+The workflow runs `scripts/sync_documentation.py`, which updates
+`docs/features.md` with:
+
+- a feature changelog entry for the merged PR
+- a feature description entry
+- usage help for maintainers and users
+
+The script is idempotent. If a PR number is already documented, it exits without
+modifying the documentation.
+
+## How a documentation PR is created
+
+When `docs/features.md` changes, the workflow creates a branch named
+`docs/sync-pr-<number>`, commits the generated documentation, pushes the branch,
+and opens a pull request back to `main`.
+
+The generated PR is intentionally reviewable rather than silently committed to
+`main`. If the merged feature PR did not include enough documentation source
+material, maintainers should expand the generated placeholder text before
+merging the documentation PR.
+
+## Recommended PR body sections
+
+Feature PRs should include these sections so the follow-up documentation PR is
+useful immediately:
+
+```markdown
+## Feature changelog
+Short user-visible release note.
+
+## Feature description
+What the feature does and why it exists.
+
+## Usage help
+Commands, setup steps, workflows, or host-specific usage notes.
+```
+
+The sync script also supports explicit extraction blocks:
+
+```markdown
+<!-- mothership-docs:changelog:start -->
+Short user-visible release note.
+<!-- mothership-docs:changelog:end -->
+
+<!-- mothership-docs:description:start -->
+What the feature does and why it exists.
+<!-- mothership-docs:description:end -->
+
+<!-- mothership-docs:usage:start -->
+Commands, setup steps, workflows, or host-specific usage notes.
+<!-- mothership-docs:usage:end -->
+```

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,60 @@
+# Feature Documentation
+
+This page is the canonical feature documentation index for Mothership. It is
+updated after feature-bearing pull requests merge to `main`, then refined in the
+follow-up documentation PR when a generated entry needs more detail.
+
+## What each feature entry must include
+
+Every documented feature should include:
+
+- a changelog entry that identifies the merged PR and the user-visible change
+- a feature description that explains the capability and why it exists
+- usage help that tells maintainers how to install, configure, or invoke it
+
+## Authoring source material in feature PRs
+
+The documentation sync job can produce better follow-up PRs when feature PRs
+include one or more of these sections in the PR body:
+
+```markdown
+## Feature changelog
+Short user-visible release note.
+
+## Feature description
+What the feature does and why it exists.
+
+## Usage help
+Commands, setup steps, workflows, or host-specific usage notes.
+```
+
+For more precise extraction, maintainers can use these HTML comment blocks in a
+PR body:
+
+```markdown
+<!-- mothership-docs:changelog:start -->
+Short user-visible release note.
+<!-- mothership-docs:changelog:end -->
+
+<!-- mothership-docs:description:start -->
+What the feature does and why it exists.
+<!-- mothership-docs:description:end -->
+
+<!-- mothership-docs:usage:start -->
+Commands, setup steps, workflows, or host-specific usage notes.
+<!-- mothership-docs:usage:end -->
+```
+
+If a feature PR does not include documentation source material, the generated
+follow-up documentation PR contains a placeholder that must be expanded before
+it is merged.
+
+## Feature Changelog
+
+<!-- mothership-docs:changelog:start -->
+<!-- mothership-docs:changelog:end -->
+
+## Feature Catalog
+
+<!-- mothership-docs:features:start -->
+<!-- mothership-docs:features:end -->

--- a/scripts/sync_documentation.py
+++ b/scripts/sync_documentation.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Synchronize generated feature documentation for a merged pull request.
+
+The script is intentionally deterministic so it can run in GitHub Actions without
+an LLM dependency. It records each feature-bearing merged PR once and preserves
+manual edits around the managed documentation region.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC_PATH = ROOT / "docs" / "features.md"
+
+CHANGELOG_START = "<!-- mothership-docs:changelog:start -->"
+CHANGELOG_END = "<!-- mothership-docs:changelog:end -->"
+FEATURES_START = "<!-- mothership-docs:features:start -->"
+FEATURES_END = "<!-- mothership-docs:features:end -->"
+
+DEFAULT_DOC = f"""# Feature Documentation
+
+This page is the canonical feature documentation index for Mothership. It is
+updated after feature-bearing pull requests merge to `main`, then refined in the
+follow-up documentation PR when a generated entry needs more detail.
+
+## What each feature entry must include
+
+Every documented feature should include:
+
+- a changelog entry that identifies the merged PR and the user-visible change
+- a feature description that explains the capability and why it exists
+- usage help that tells maintainers how to install, configure, or invoke it
+
+## Feature Changelog
+
+{CHANGELOG_START}
+{CHANGELOG_END}
+
+## Feature Catalog
+
+{FEATURES_START}
+{FEATURES_END}
+"""
+
+DOC_ONLY_PREFIXES = (
+    "docs/",
+    ".github/",
+)
+DOC_ONLY_FILES = {
+    "README.md",
+    "AGENTS.md",
+}
+FEATURE_PREFIXES = (
+    "agents/",
+    "mothership-config/",
+    "skills/",
+    "tools/",
+)
+FEATURE_FILES = {
+    "install.sh",
+}
+
+
+def run_git(args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout.strip()
+
+
+def changed_paths_for_commit(commit: str) -> list[str]:
+    if not commit:
+        return []
+    output = run_git(["diff-tree", "--no-commit-id", "--name-only", "-r", commit])
+    return [line for line in output.splitlines() if line]
+
+
+def is_feature_path(path: str) -> bool:
+    return path in FEATURE_FILES or path.startswith(FEATURE_PREFIXES)
+
+
+def is_docs_only(paths: Iterable[str]) -> bool:
+    paths = list(paths)
+    if not paths:
+        return False
+    return all(path in DOC_ONLY_FILES or path.startswith(DOC_ONLY_PREFIXES) for path in paths)
+
+
+def extract_heading_section(body: str, aliases: Iterable[str]) -> str:
+    aliases_norm = {alias.lower() for alias in aliases}
+    lines = body.replace("\r\n", "\n").split("\n")
+    for index, line in enumerate(lines):
+        match = re.match(r"^(#{1,6})\s+(.+?)\s*$", line)
+        if not match:
+            continue
+        level = len(match.group(1))
+        title = re.sub(r"[^a-z0-9 ]+", "", match.group(2).lower()).strip()
+        if title not in aliases_norm:
+            continue
+        collected: list[str] = []
+        for next_line in lines[index + 1 :]:
+            next_match = re.match(r"^(#{1,6})\s+", next_line)
+            if next_match and len(next_match.group(1)) <= level:
+                break
+            collected.append(next_line)
+        return "\n".join(collected).strip()
+    return ""
+
+
+def extract_comment_block(body: str, name: str) -> str:
+    pattern = re.compile(
+        rf"<!--\s*mothership-docs:{re.escape(name)}:start\s*-->(.*?)<!--\s*mothership-docs:{re.escape(name)}:end\s*-->",
+        re.IGNORECASE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    return match.group(1).strip() if match else ""
+
+
+def first_meaningful_paragraph(body: str) -> str:
+    cleaned_lines: list[str] = []
+    for raw_line in body.replace("\r\n", "\n").split("\n"):
+        line = raw_line.strip()
+        if not line or line.startswith("<!--") or line.startswith("#"):
+            if cleaned_lines:
+                break
+            continue
+        if line.startswith(("- [ ]", "- [x]", "- [X]")):
+            continue
+        cleaned_lines.append(line)
+    return " ".join(cleaned_lines).strip()
+
+
+def normalize_block(text: str, fallback: str) -> str:
+    text = text.strip()
+    if not text:
+        return fallback
+    return text
+
+
+def markdown_list(items: list[str], limit: int = 12) -> str:
+    shown = items[:limit]
+    lines = [f"  - `{item}`" for item in shown]
+    if len(items) > limit:
+        lines.append(f"  - …and {len(items) - limit} more")
+    return "\n".join(lines) if lines else "  - _No changed paths were available._"
+
+
+def ensure_doc() -> str:
+    if not DOC_PATH.exists():
+        DOC_PATH.parent.mkdir(parents=True, exist_ok=True)
+        DOC_PATH.write_text(DEFAULT_DOC, encoding="utf-8")
+    text = DOC_PATH.read_text(encoding="utf-8")
+    for marker in (CHANGELOG_START, CHANGELOG_END, FEATURES_START, FEATURES_END):
+        if marker not in text:
+            raise SystemExit(f"{DOC_PATH} is missing required marker: {marker}")
+    return text
+
+
+def insert_after_marker(text: str, start: str, entry: str) -> str:
+    return text.replace(start, f"{start}\n\n{entry.strip()}\n", 1)
+
+
+def build_entries(args: argparse.Namespace, paths: list[str]) -> tuple[str, str]:
+    body = args.pr_body or ""
+    summary = normalize_block(
+        extract_comment_block(body, "changelog")
+        or extract_heading_section(body, ["feature changelog", "changelog", "summary"])
+        or first_meaningful_paragraph(body),
+        f"Merged `{args.pr_title}`. Review and expand this generated changelog summary if the PR body did not include release-note detail.",
+    )
+    description = normalize_block(
+        extract_comment_block(body, "description")
+        or extract_heading_section(body, ["feature description", "feature descriptions", "description", "what changed"]),
+        f"`{args.pr_title}` introduced or changed feature behavior in the files listed below. Review the merged implementation and replace this generated placeholder with a maintainer-authored description before merging the documentation PR.",
+    )
+    usage = normalize_block(
+        extract_comment_block(body, "usage")
+        or extract_heading_section(body, ["usage help", "usage", "how to use", "testing"]),
+        "Usage help was not provided in the merged PR body. Document the commands, setup steps, host-specific behavior, or operator workflow required to use this change before merging the documentation PR.",
+    )
+    merged_at = args.merged_at or dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    merge_sha = args.merge_sha or "unknown"
+    source = args.pr_url or f"PR #{args.pr_number}"
+    path_list = markdown_list(paths)
+
+    changelog = f"""<!-- mothership-docs:pr:{args.pr_number}:changelog -->
+### PR #{args.pr_number} — {args.pr_title}
+
+- **Merged:** {merged_at}
+- **Source:** {source}
+- **Merge commit:** `{merge_sha}`
+- **Change summary:** {summary}
+- **Changed paths:**
+{path_list}
+"""
+
+    feature = f"""<!-- mothership-docs:pr:{args.pr_number}:feature -->
+### PR #{args.pr_number} — {args.pr_title}
+
+**Feature description**
+
+{description}
+
+**Usage help**
+
+{usage}
+"""
+    return changelog, feature
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr-number", required=True)
+    parser.add_argument("--pr-title", required=True)
+    parser.add_argument("--pr-url", default="")
+    parser.add_argument("--pr-body", default="")
+    parser.add_argument("--pr-body-file", default="")
+    parser.add_argument("--merge-sha", default="")
+    parser.add_argument("--merged-at", default="")
+    parser.add_argument("--changed-path", action="append", default=[])
+    args = parser.parse_args()
+    if args.pr_body_file:
+        args.pr_body = Path(args.pr_body_file).read_text(encoding="utf-8")
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    paths = args.changed_path or changed_paths_for_commit(args.merge_sha)
+    paths = sorted(dict.fromkeys(paths))
+
+    if is_docs_only(paths):
+        print("Merged PR only changed documentation or automation files; no feature documentation sync needed.")
+        return
+    if paths and not any(is_feature_path(path) for path in paths):
+        print("Merged PR did not touch a recognized feature path; no feature documentation sync needed.")
+        return
+
+    text = ensure_doc()
+    pr_marker = f"<!-- mothership-docs:pr:{args.pr_number}:"
+    if pr_marker in text:
+        print(f"PR #{args.pr_number} is already documented.")
+        return
+
+    changelog, feature = build_entries(args, paths)
+    text = insert_after_marker(text, CHANGELOG_START, changelog)
+    text = insert_after_marker(text, FEATURES_START, feature)
+    DOC_PATH.write_text(text, encoding="utf-8")
+    print(f"Updated {DOC_PATH.relative_to(ROOT)} for PR #{args.pr_number}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Ensure every feature-bearing merge to `main` has corresponding user-facing documentation by generating a follow-up PR when docs need updating.
- Make the generation deterministic and reviewable so maintainers can expand placeholders and keep docs authoritative.

### Description
- Add a GitHub Actions workflow at `.github/workflows/documentation-sync.yml` that runs after merged PRs to `main` or via `workflow_dispatch`, collects PR metadata, invokes the generator, and opens/updates a reviewable docs PR when `docs/features.md` changes. 
- Add a deterministic generator script at `scripts/sync_documentation.py` that detects feature-bearing changes, extracts `Feature changelog`/`Feature description`/`Usage help` from PR bodies or comment markers, inserts idempotent entries into `docs/features.md`, and skips docs-only or non-feature changes. 
- Add scaffolded documentation at `docs/features.md` and `docs/documentation-sync.md` describing required feature entry fields, supported PR body markers, and the workflow behavior. 
- Update `README.md` to advertise the documentation sync flow and list the new workflow, docs, and generator in the repository layout.

### Testing
- Ran `python3 -m py_compile scripts/sync_documentation.py` and the script compiled successfully. 
- Validated the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/documentation-sync.yml")'` which succeeded. 
- Exercised the generator end-to-end by running `scripts/sync_documentation.py` with a sample PR body and changed paths and verified expected entries appear in `docs/features.md`. 
- Ran `go test ./...` in `tools/installer` and the installer tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c57a1224c8320b8049719e5c189b8)