### PR TITLE
Add execution profiles (quick/standard/strict) with profile-aware model routing and hub fields

### DIFF
--- a/.mothership/hub/README.md
+++ b/.mothership/hub/README.md
@@ -1,7 +1,12 @@
-# Local Hub State
+# Hub Contract
 
-The local hub is the operational memory of mothership. It lives under `.mothership/hub/`
-and is gitignored (runtime agent context only).
+This file is the canonical, version-controlled copy of the hub contract.
+It is mirrored at `.mothership/hub/README.md` at runtime.
+
+**Do not edit `.mothership/hub/README.md` directly** — edit this file instead,
+and copy it to the runtime location during warmup.
+
+---
 
 ## Design
 
@@ -25,6 +30,11 @@ state: coding
 prev: planning
 entered: 2026-05-16T14:32:00Z
 overlay: null
+profile: standard
+profile_reason: Normal multi-file bugfix with routine risk
+profile_selected_at: 2026-05-16T14:30:00Z
+profile_detection_hints:
+  - Multi-file behavior change
 risk: medium
 gh:
   issue: "#42"
@@ -76,6 +86,10 @@ coding:
 
 | Key | Type | Description |
 |-----|------|-------------|
+| `profile` | enum | `quick`, `standard`, or `strict`; selected during intake |
+| `profile_reason` | string | Why the profile was selected |
+| `profile_selected_at` | string | ISO timestamp when profile was selected |
+| `profile_detection_hints` | list | Decisive hints used to classify the task |
 | `risk` | enum | `low`, `medium`, `high`, `critical` |
 | `gh` | object | GitHub references: `issue`, `pr` |
 | `agents` | object | Role → status/agent_type map |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ The [model-policy.yaml](mothership-config/model-policy.yaml) file controls:
 
 - **host aliases**: Map local host names to supported targets (`claude`, `codex`, `pi`, `hermes`)
 - **role tiers**: Assign model tiers per role (`commander`, `researcher`, `coder`, `qa`, `pr_monkey`)
+- **profile overrides**: Adjust tier selection based on execution profile (`quick`/`standard`/`strict`)
 - **risk overrides**: Adjust tier selection based on task risk (`low`/`medium`/`high`)
 - **host models**: Define available models per host and tier
 - **fallback behavior**: How to handle missing/invalid config
@@ -99,18 +100,36 @@ host_aliases:
   hermes: hermes
 
 # Role tiers - map each role to a model tier
-tiers:
+role_tiers:
   commander: high
   researcher: medium
   coder: medium
   qa: low
   pr_monkey: low
 
+# Profile overrides - adjust tier based on workflow ceremony
+profile_overrides:
+  quick:
+    researcher: low
+    coder: low
+    qa: low
+  standard: {}
+  strict:
+    commander: high
+    researcher: high
+    coder: high
+    qa: high
+
 # Risk overrides - adjust tier based on task risk
-risk:
-  low: low
-  medium: medium
-  high: high
+risk_overrides:
+  low:
+    coder: low
+    qa: low
+  medium: {}
+  high:
+    researcher: high
+    coder: high
+    qa: high
 
 # Host models - available models per host and tier
 host_models:
@@ -125,9 +144,12 @@ host_models:
 ```
 
 Model resolution order:
-1. Role tier + risk override from this file
-2. Host-specific model mapping in `agents/registry.yaml`
-3. Fallback: inherit from current session model
+1. Explicit invocation override, if provided
+2. Profile override from `profile_overrides`
+3. Risk override from `risk_overrides`
+4. Role tier from `role_tiers`
+5. Host-specific model mapping in `agents/registry.yaml`
+6. Fallback: inherit from current session model
 
 ### Verifying Configuration
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,38 @@ Examples:
 
 That discipline is what makes the workflow useful in real repos over time.
 
+
+## Execution Profiles
+
+Mothership supports three execution profiles so daily work does not always need
+the same ceremony as high-risk engineering changes. The commander selects one
+profile during `intake`, records the choice and rationale in hub state, and then
+uses that profile to size research, planning, QA, PR expectations, and model
+routing.
+
+| Profile | Best for | Research | Planning | QA | PR | Model tier intent |
+| --- | --- | --- | --- | --- | --- | --- |
+| `quick` | Tiny fix, doc/content change, cosmetic update, or single-line config | Skip or minimal with a recorded rationale | Concise checklist | Light but mandatory | Optional | Low-to-medium |
+| `standard` | Normal feature, bugfix, or routine multi-file maintenance | Normal | Normal | Normal | Required | Standard role/risk tiers |
+| `strict` | Security, architecture, persistence, auth, crypto, secrets, hub/config, install, or model-routing changes | Deep | High-model detailed plan | Full review with security/boundary checks | Required | High first pass |
+
+Auto-detection hints favor safety:
+
+- one file, documentation-only, cosmetic, or low-blast-radius config changes usually indicate `quick`
+- three or more files or ordinary behavior changes usually indicate `standard`
+- sensitive terms such as password, token, auth, crypto, secret, permission, or policy indicate `strict`
+- changes touching `.mothership/hub/`, `mothership-config/`, persistence, serialization, installer behavior, or model routing indicate `strict`
+- when hints conflict, the commander chooses the stricter profile
+
+Profiles adjust ceremony; they do not delete workflow states. Even `quick` tasks
+still enter research, planning, coding, and QA. The difference is that quick
+research may be satisfied by a recorded `skip_or_minimal` rationale, planning may
+be a concise checklist, and QA remains a focused but explicit verification step.
+
+Model routing can also respect profiles through
+`mothership-config/model-policy.yaml` using `profile_overrides` before risk and
+role defaults.
+
 ## How Mothership Maintains Work
 
 Mothership is built around the idea that engineering work should remain

--- a/agents/commander.md
+++ b/agents/commander.md
@@ -12,8 +12,9 @@ The commander is the only role allowed to communicate directly with the human.
 - Create and maintain local hub state.
 - Follow the canonical workflow defined in `mothership-config/workflow.yaml`.
 - Run `intake` warm-up checklist before transitioning out of `intake`.
-- Analyze complexity, risk, and execution approach.
-- Route every task through explicit `research` before `planning`.
+- Analyze complexity, risk, execution profile, and execution approach.
+- Select `quick`, `standard`, or `strict` during intake and record the choice in hub state.
+- Route every task through the canonical states with profile-appropriate ceremony before `planning`.
 - Enforce brainstorming and plan-making gates before `coding`.
 - Read the roles registry before assigning work.
 - Verify required external skills from `mothership-config/skill-dependencies.md`.
@@ -33,6 +34,7 @@ The commander is the only role allowed to communicate directly with the human.
 - Local hub state (`.mothership/hub/state.yaml`)
 - `mothership-config/roles.md`
 - `mothership-config/workflow.yaml`
+- Selected execution profile (`quick`, `standard`, or `strict`)
 - Research issue outputs
 - GitHub issues, comments, labels, and PR state
 - Machine resource signals such as CPU, memory, and disk availability
@@ -132,6 +134,26 @@ The commander must manage each task through the canonical workflow states in
 The commander must not invent ad hoc phase names when a task fits one of the
 canonical states.
 
+### Execution profiles
+
+The commander must choose an execution profile during `intake` and record it in hub state as `profile`, with `profile_reason`, `profile_selected_at`, and any decisive `profile_detection_hints`.
+
+| Profile | Use for | Research | Planning | QA | PR | Model routing |
+| --- | --- | --- | --- | --- | --- | --- |
+| `quick` | Tiny fix, doc/content change, cosmetic update, or single-line config with low blast radius | `skip_or_minimal` with recorded rationale | concise checklist | light but mandatory | optional | low-to-medium tiers |
+| `standard` | Normal feature, bugfix, or routine multi-file change | normal | normal | normal | required | standard role/risk tiers |
+| `strict` | Security, architecture, persistence, auth, crypto, secrets, hub/config, install, or model-routing change | deep | high-model detailed plan | full review with security/boundary checks | required | high-first-pass tiers |
+
+Auto-detection hints:
+
+- One file, documentation-only, cosmetic, or tiny config changes usually start as `quick`.
+- Three or more files, normal behavior changes, or ambiguous coupling usually start as `standard`.
+- Sensitive keywords such as password, token, auth, crypto, secret, permission, or policy imply `strict`.
+- Changes touching `.mothership/hub/`, `mothership-config/`, persistence, serialization, installer behavior, or model routing imply `strict`.
+- When hints conflict, choose the stricter profile.
+
+Profiles tune the amount of ceremony required inside each canonical state. They do not remove the state itself: even `quick` enters `research`, `planning`, and `qa`, but may satisfy research with a documented `skip_or_minimal` disposition and planning with a concise checklist. QA must never be skipped.
+
 ### State discipline
 
 These rules are mandatory:
@@ -139,7 +161,7 @@ These rules are mandatory:
 - **Declare every transition.** Before beginning work in a new state, announce the transition explicitly (e.g., `Transition: research → planning`).
 - **Verify transitions are allowed.** Check `allowed_transitions` in `mothership-config/workflow.yaml` before transitioning. Invalid transitions must not happen.
 - **Do work only for the current state.** Do not research during planning. Do not code during research. Do not plan during intake. Each state has defined work — do that work and nothing else.
-- **Do not skip states.** Even if the problem seems simple, every state must be entered and its exit criteria must be met before transitioning out. "Small task" is not a valid reason to collapse the state machine.
+- **Do not skip states.** Every state must be entered and its profile-adjusted exit criteria must be met before transitioning out. A `quick` task may use minimal research or concise planning only when that disposition is explicitly recorded.
 - **Do not mentally label without doing the work.** Saying "I've done research" is not research. Reading the relevant files and recording structured findings is research.
 
 ### Phase skill routing
@@ -165,9 +187,9 @@ The commander orchestrates. It does not implement, research, or review directly.
 
 ### Delegation rules
 
-- **Research phase:** Spawn a sub-agent to perform research. Pass the research issue context, require `obra/brainstorming` in research mode plus `obra/making-plans`, and include the agent file at `agents/researcher.md` as the role contract. Do not research yourself.
-- **Coding phase:** Spawn a sub-agent to implement. Pass the approved implementation plan, branch context, require `obra/executing-plans`, and include the agent file at `agents/coder.md` as the role contract. Do not implement yourself.
-- **QA phase:** Spawn a sub-agent to review. Pass the PR diff, research findings, and the agent file at `agents/qa.md` as the role contract. Do not review your own implementation.
+- **Research phase:** Follow the selected profile. For `quick`, record the `skip_or_minimal` rationale or spawn a lightweight researcher when context is still needed. For `standard` and `strict`, spawn a sub-agent to perform research. Pass the research issue context, require `obra/brainstorming` in research mode plus `obra/making-plans`, and include the agent file at `agents/researcher.md` as the role contract. Do not research yourself when delegated research is required.
+- **Coding phase:** Spawn a sub-agent to implement. Pass the approved implementation plan or profile-appropriate checklist, branch context, selected profile, require `obra/executing-plans`, and include the agent file at `agents/coder.md` as the role contract. Do not implement yourself.
+- **QA phase:** Spawn a sub-agent to review. Pass the PR diff or implementation checkpoint, research findings or skip rationale, selected profile, and the agent file at `agents/qa.md` as the role contract. Do not review your own implementation. QA is mandatory for every profile.
 - **PR operations:** Spawn a sub-agent to handle PR creation, PR feedback triage, comment replies, and thread resolution. Pass PR context and the agent file at `agents/pr_monkey.md` as the role contract. Do not create or maintain PRs yourself when the task is explicitly PR-oriented.
 
 ### PR feedback discipline
@@ -209,10 +231,11 @@ Sub-agent model selection should resolve through `mothership-config/model-policy
 
 Resolution order:
 1. Explicit invocation override (if provided)
-2. Risk override in `risk_overrides` (when a risk level is known)
-3. Role tier mapping in `role_tiers`
-4. Host tier default via `host_aliases` + `host_models`/`tiers`
-5. Fallback: inherit current thread model (legacy behavior)
+2. Profile override in `profile_overrides` (when a profile is selected)
+3. Risk override in `risk_overrides` (when a risk level is known)
+4. Role tier mapping in `role_tiers`
+5. Host tier default via `host_aliases` + `host_models`/`tiers`
+6. Fallback: inherit current thread model (legacy behavior)
 
 If `model-policy.yaml` is missing or invalid, warn and continue with legacy inheritance.
 

--- a/mothership-config/hub-contract.md
+++ b/mothership-config/hub-contract.md
@@ -30,6 +30,11 @@ state: coding
 prev: planning
 entered: 2026-05-16T14:32:00Z
 overlay: null
+profile: standard
+profile_reason: Normal multi-file bugfix with routine risk
+profile_selected_at: 2026-05-16T14:30:00Z
+profile_detection_hints:
+  - Multi-file behavior change
 risk: medium
 gh:
   issue: "#42"
@@ -81,6 +86,10 @@ coding:
 
 | Key | Type | Description |
 |-----|------|-------------|
+| `profile` | enum | `quick`, `standard`, or `strict`; selected during intake |
+| `profile_reason` | string | Why the profile was selected |
+| `profile_selected_at` | string | ISO timestamp when profile was selected |
+| `profile_detection_hints` | list | Decisive hints used to classify the task |
 | `risk` | enum | `low`, `medium`, `high`, `critical` |
 | `gh` | object | GitHub references: `issue`, `pr` |
 | `agents` | object | Role → status/agent_type map |

--- a/mothership-config/model-policy.yaml
+++ b/mothership-config/model-policy.yaml
@@ -7,6 +7,7 @@ fallback:
   legacy_behavior: "When no valid policy is available, delegation keeps legacy model inheritance."
   resolution_order:
     - explicit_override
+    - profile_override
     - risk_override
     - role_tier
     - host_tier_default
@@ -27,6 +28,24 @@ role_tiers:
   coder: medium
   qa: medium
   pr_monkey: low
+
+
+# Optional profile-based overrides. Applied after explicit invocation overrides
+# and before risk/role defaults so execution profiles can right-size ceremony.
+profile_overrides:
+  quick:
+    commander: medium
+    researcher: low
+    coder: low
+    qa: low
+    pr_monkey: low
+  standard: {}
+  strict:
+    commander: high
+    researcher: high
+    coder: high
+    qa: high
+    pr_monkey: medium
 
 # Optional risk-based overrides.
 risk_overrides:

--- a/mothership-config/workflow.yaml
+++ b/mothership-config/workflow.yaml
@@ -4,6 +4,73 @@ description: >
   normal task lifecycle, allowed state transitions, and non-phase overlays
   used for recovery and interruption handling.
 
+profiles:
+  quick:
+    description: "Tiny fix, documentation-only change, cosmetic update, or single-line config adjustment."
+    detection_hints:
+      - "Likely touches one file or one tightly scoped documentation/config area."
+      - "Purely cosmetic/content changes with no persistence, auth, crypto, or infrastructure boundary."
+    phase_behavior:
+      intake: "Select and record the profile, success criteria, risk, and why deeper ceremony is unnecessary."
+      research: "skip_or_minimal; record the reason research is unnecessary or capture a short file/context note."
+      planning: "concise; record a short implementation checklist instead of a full design narrative."
+      coding: "auto; one coder path unless the host workflow has an explicit reason to split."
+      qa: "light; run relevant focused checks or human-verifiable review, but never skip QA entirely."
+    pr_required: false
+    model_policy:
+      default_risk: low
+      tier_hint: low_to_medium
+
+  standard:
+    description: "Normal feature, bugfix, or multi-file maintenance task with routine engineering risk."
+    detection_hints:
+      - "Likely touches two or more files or changes behavior that deserves normal review."
+      - "No sensitive security, persistence, or architecture boundary dominates the task."
+    phase_behavior:
+      intake: "Record success criteria, risk, profile rationale, and dependencies."
+      research: "normal; validate assumptions and produce a planning-ready handoff."
+      planning: "normal; create an explicit implementation plan and delegation shape."
+      coding: "auto; choose single-agent or multi-agent execution based on coupling."
+      qa: "normal; review against scope, risk, and research findings."
+    pr_required: true
+    model_policy:
+      default_risk: medium
+      tier_hint: standard
+
+  strict:
+    description: "Security, architecture, persistence, auth, crypto, secrets, or high-blast-radius change."
+    detection_hints:
+      - "Task mentions password, token, auth, crypto, secrets, permissions, or policy enforcement."
+      - "Changes touch `.mothership/hub/`, `mothership-config/`, persistence, serialization, install paths, or model routing."
+      - "Failure could lose data, weaken security, break orchestration, or affect multiple hosts."
+    phase_behavior:
+      intake: "Record strict rationale, sensitive boundaries, risk, dependencies, and QA obligations."
+      research: "deep; explicitly investigate risk, compatibility, and boundary behavior."
+      planning: "high_model; require detailed plan, rollback considerations, and security/persistence constraints."
+      coding: "with_security_constraints; keep ownership boundaries explicit and avoid shortcuts."
+      qa: "full_with_security_review; verify boundary behavior and run the strongest available checks."
+    pr_required: true
+    model_policy:
+      default_risk: high
+      tier_hint: high_first_pass
+
+profile_selection:
+  required_state: intake
+  default_profile: standard
+  hub_fields:
+    - profile
+    - profile_reason
+    - profile_selected_at
+    - profile_detection_hints
+  rules:
+    - "Commander must choose `quick`, `standard`, or `strict` during intake before leaving intake."
+    - "Commander must record the selected profile and rationale in hub state."
+    - "Profiles adjust phase ceremony; they do not remove canonical workflow states."
+    - "Quick may satisfy research with a recorded skip_or_minimal rationale and planning with a concise checklist."
+    - "QA is mandatory for every profile, including quick."
+    - "When hints conflict, choose the stricter profile."
+    - "Model tier routing must consider profile before risk and role defaults."
+
 states:
   intake:
     purpose: Capture the incoming request, initialize hub state, and clarify the problem before research begins.
@@ -17,6 +84,7 @@ states:
       - "Auxiliary skill preflight is recorded from `mothership-config/skill-dependencies.md`."
       - "`obra/brainstorming` is invoked to restate the task, assumptions, and success criteria."
       - Task summary is recorded in the hub.
+      - Execution profile (`quick`, `standard`, or `strict`) and profile rationale are recorded in the hub.
       - Initial risk assessment is recorded.
       - Success criteria and obvious dependencies are noted.
       - "Wiki index is read for project context if wiki is configured."
@@ -28,10 +96,11 @@ states:
       - waiting_for_human
       - blocked
     exit_criteria:
-      - "Research sub-agent is invoked using `agents/registry.yaml`."
-      - "Research sub-agent invokes `obra/brainstorming` in research mode."
-      - Research sub-agent output or blocker is recorded.
-      - Research findings are written to GitHub.
+      - "Research disposition is selected from the active profile; delegated research is invoked using `agents/registry.yaml` when the profile requires it."
+      - "When a research sub-agent is invoked, it uses `obra/brainstorming` in research mode."
+      - Research sub-agent output, minimal research note, or skip rationale is recorded.
+      - "Research depth follows the selected profile (`skip_or_minimal`, `normal`, or `deep`) and the profile-specific research disposition is recorded."
+      - Research findings are written to GitHub when required by the selected profile.
       - Open questions are identified.
       - "Research findings are structured with `obra/making-plans` into a planning-ready handoff."
       - Risks and constraints are summarized for planning.
@@ -45,7 +114,8 @@ states:
       - blocked
     exit_criteria:
       - "`obra/brainstorming` is invoked in interactive mode to present the design."
-      - "`obra/making-plans` is invoked and an explicit implementation plan is recorded."
+      - "Planning depth follows the selected profile (`concise`, `normal`, or `high_model`)."
+      - "`obra/making-plans` is invoked and an explicit implementation plan or profile-appropriate concise checklist is recorded."
       - Single-agent or multi-agent decision is recorded.
       - Implementation issues are created or updated.
       - Worktree allocation decision is recorded.
@@ -74,6 +144,7 @@ states:
     exit_criteria:
       - "QA sub-agent is invoked using `agents/registry.yaml`."
       - QA sub-agent output or blocker is recorded.
+      - "QA depth follows the selected profile (`light`, `normal`, or `full_with_security_review`), but QA is never skipped."
       - QA disposition is recorded.
       - Required changes or escalation reason is explicit.
       - "L1 items confirmed or challenged by QA are noted in `.draft/<task-id>/notes.md` if wiki is configured."
@@ -183,6 +254,8 @@ hub_contract:
     - entered
     - overlay
   recommended_fields:
+    - profile
+    - profile_reason
     - risk
     - gh
     - agents

--- a/skills/model-policy-setup/scripts/setup-model-policy.sh
+++ b/skills/model-policy-setup/scripts/setup-model-policy.sh
@@ -26,6 +26,7 @@ fallback:
   legacy_behavior: "When no valid policy is available, delegation keeps legacy model inheritance."
   resolution_order:
     - explicit_override
+    - profile_override
     - risk_override
     - role_tier
     - host_tier_default
@@ -46,6 +47,24 @@ role_tiers:
   coder: medium
   qa: medium
   pr_monkey: low
+
+
+# Optional profile-based overrides. Applied after explicit invocation overrides
+# and before risk/role defaults so execution profiles can right-size ceremony.
+profile_overrides:
+  quick:
+    commander: medium
+    researcher: low
+    coder: low
+    qa: low
+    pr_monkey: low
+  standard: {}
+  strict:
+    commander: high
+    researcher: high
+    coder: high
+    qa: high
+    pr_monkey: medium
 
 # Optional risk-based overrides.
 risk_overrides:

--- a/skills/mothership/SKILL.md
+++ b/skills/mothership/SKILL.md
@@ -23,7 +23,7 @@ Run this checklist immediately when `mothership` is invoked:
 3. Ensure `.mothership/` is present in `.gitignore`.
 4. Ensure required auxiliary skills are available per `mothership-config/skill-dependencies.md`.
 5. Ensure `agents/registry.yaml` and `skills/mothership/subagent-protocol.md` are available.
-6. If `mothership-config/model-policy.yaml` is missing, run `skills/model-policy-setup/scripts/setup-model-policy.sh` to bootstrap it. Inform the user they should edit the `host_models` section to match their available models.
+6. If `mothership-config/model-policy.yaml` is missing, run `skills/model-policy-setup/scripts/setup-model-policy.sh` to bootstrap it. Inform the user they should edit the `host_models` and optional `profile_overrides` sections to match their available models and desired profile routing.
 7. If preflight fails, record a `blocked` overlay or explicit fallback notes before continuing.
 8. If `.mothership/wiki.yaml` exists, read `projects/<name>/index.md` from the configured wiki root for project context.
 9. On pi: verify the `mothership_spawn` extension is available under `$PI_HOME/extensions/` (default `~/.agents/extensions/`). If absent, delegation will not work — record a `blocked` overlay and continue without sub-agent spawning.
@@ -96,6 +96,19 @@ role_tiers:
   qa: medium
   pr_monkey: low
 
+# Profile-based overrides (applied before risk/role defaults)
+profile_overrides:
+  quick:
+    researcher: low
+    coder: low
+    qa: low
+  standard: {}
+  strict:
+    commander: high
+    researcher: high
+    coder: high
+    qa: high
+
 # Risk-based overrides (applied before role_tiers)
 risk_overrides:
   low:
@@ -109,10 +122,11 @@ risk_overrides:
 Key sections:
 - **`host_models.<host>`** — map tier names to actual model IDs your provider supports
 - **`role_tiers`** — change which tier a role uses by default
+- **`profile_overrides`** — upgrade or downgrade role tiers for `quick`, `standard`, or `strict` profiles
 - **`risk_overrides`** — upgrade or downgrade based on task risk assessment
 - **`fallback`** — what happens when policy is missing or invalid (default: warn + inherit current thread model)
 
-Resolution order: explicit_override → risk_override → role_tier → host_tier_default → inherit_current_thread_model
+Resolution order: explicit_override → profile_override → risk_override → role_tier → host_tier_default → inherit_current_thread_model
 
 After editing, validate:
 ```bash
@@ -158,10 +172,11 @@ After warmup completes:
 
 1. Declare the current workflow state. The initial state is always `intake`.
 2. Record the task summary in the hub.
-3. Use `obra/brainstorming` during `intake` before any delegation.
-4. Follow the state machine from `mothership-config/workflow.yaml` — do not skip ahead.
-5. If wiki is configured, L1 staging writes happen automatically during research, planning, coding, and QA states.
-6. L2 promotion happens automatically at `complete`.
+3. Select an execution profile (`quick`, `standard`, or `strict`) during `intake` and record `profile`, `profile_reason`, `profile_selected_at`, and decisive detection hints in the hub.
+4. Use `obra/brainstorming` during `intake` before any delegation.
+5. Follow the state machine from `mothership-config/workflow.yaml` with profile-appropriate ceremony — do not skip states.
+6. If wiki is configured, L1 staging writes happen automatically during research, planning, coding, and QA states.
+7. L2 promotion happens automatically at `complete`.
 
 The agent must be in a state at all times. Between states there is no undefined "just working" mode.
 
@@ -169,12 +184,23 @@ The agent must be in a state at all times. Between states there is no undefined 
 
 - Commander remains the sole human-facing role.
 - Use the canonical workflow states from `mothership-config/workflow.yaml`.
+- Use execution profiles from `workflow.yaml` to right-size ceremony without removing states.
 - Treat `blocked` and `reconstructed` as overlays rather than standalone phases.
 - Persist important checkpoints to GitHub as well as local hub state.
 
 ## Workflow Discipline
 
 These rules are mandatory, not advisory.
+
+### Execution profiles must be selected during intake
+
+Classify every task as exactly one profile:
+
+- `quick`: tiny fix, doc/content-only change, cosmetic update, or single-line config. Research may be `skip_or_minimal`, planning may be concise, QA is light but mandatory, and PRs are optional.
+- `standard`: normal feature or bugfix. Use normal research, planning, QA, and PR expectations.
+- `strict`: security, architecture, persistence, auth, crypto, secrets, hub/config, install, or model-routing work. Use deep research, high-model planning, full QA/security review, and PRs.
+
+Record `profile`, `profile_reason`, `profile_selected_at`, and decisive `profile_detection_hints` in hub state before leaving `intake`. If hints conflict, choose the stricter profile.
 
 ### State transitions must be explicit
 
@@ -214,7 +240,7 @@ Mothership is an orchestration system. After reading the task and completing int
 5. Spawn a sub-agent to review.
 6. Close the loop.
 
-Do not skip from "I understand the task" to "here is the solution." The state machine exists precisely to prevent this pattern.
+Do not skip from "I understand the task" to "here is the solution." The state machine exists precisely to prevent this pattern. Execution profiles only adjust depth: a `quick` task can record minimal research and a concise plan, but it still reaches QA.
 
 ### Use sub-agents, not role-play
 

--- a/skills/mothership/scripts/validate-model-policy.sh
+++ b/skills/mothership/scripts/validate-model-policy.sh
@@ -91,6 +91,24 @@ else
   done
 fi
 
+
+# profile_overrides are optional for backward compatibility with existing
+# user policies. When present, validate the expected profile buckets.
+if match_line "^profile_overrides:" "${policy_file}"; then
+  profile_overrides_block="$(section_block profile_overrides || true)"
+  if [ -z "${profile_overrides_block}" ]; then
+    warn "profile_overrides block is present but empty"
+    valid=0
+  else
+    for profile in quick standard strict; do
+      if ! match_line "^  ${profile}:" <<< "${profile_overrides_block}"; then
+        warn "profile_overrides missing profile: ${profile}"
+        valid=0
+      fi
+    done
+  fi
+fi
+
 # risk_overrides (section-scoped)
 risk_overrides_block="$(section_block risk_overrides || true)"
 if [ -z "${risk_overrides_block}" ]; then

--- a/skills/task-intake-and-decomposition/SKILL.md
+++ b/skills/task-intake-and-decomposition/SKILL.md
@@ -22,9 +22,30 @@ Help commander turn an incoming human request into an actionable execution plan.
 
 - task summary
 - decomposition recommendation
+- selected execution profile (`quick`, `standard`, or `strict`) and rationale
 - initial risk level
 - research-needed flag
 - possible implementation issue breakdown
+
+## Execution Profile Classification
+
+During intake, classify the task into exactly one profile and record the chosen profile plus rationale in hub state.
+
+| Profile | Use when | Intake output requirements |
+| --- | --- | --- |
+| `quick` | Tiny fix, doc/content-only edit, cosmetic update, or single-line config with low blast radius | Record why minimal research and concise planning are sufficient; still require light QA. |
+| `standard` | Normal feature, bugfix, or routine multi-file change | Record normal research/planning expectations and QA scope. |
+| `strict` | Security, architecture, persistence, auth, crypto, secrets, hub/config, installer, or model-routing change | Record sensitive boundaries, deep research needs, high-model planning, and full QA/security review obligations. |
+
+Auto-detection hints:
+
+- One file or purely cosmetic/content changes usually indicate `quick`.
+- Three or more files, behavior changes, or unclear coupling usually indicate `standard`.
+- Keywords such as password, token, auth, crypto, secret, permission, or policy indicate `strict`.
+- Touching `.mothership/hub/`, `mothership-config/`, persistence, serialization, install paths, or model routing indicates `strict`.
+- If hints disagree, choose the stricter profile.
+
+The profile controls ceremony, not state existence: every task still reaches QA, and `quick` only lightens research/planning when the skip/minimal rationale is recorded.
 
 ## Boundary Definition
 


### PR DESCRIPTION
### Motivation

- Introduce execution profiles so the workflow can right-size ceremony for tiny fixes, normal work, and high-risk changes without removing canonical states.
- Make model routing profile-aware so role-tier selection can be adjusted by the chosen profile before risk/role defaults.
- Record profile metadata in the hub state so intake captures the chosen profile and rationale for later phases and audits.

### Description

- Add three execution profiles (`quick`, `standard`, `strict`) and profile-selection rules to `mothership-config/workflow.yaml`, including profile-specific phase behaviors and required hub fields (`profile`, `profile_reason`, `profile_selected_at`, `profile_detection_hints`).
- Extend the hub contract and runtime README (`mothership-config/hub-contract.md`, `.mothership/hub/README.md`) to include the profile fields and sample state entries, and clarify `.mothership/hub/README.md` as a runtime mirror (do not edit runtime copy directly).
- Make model policy profile-aware by adding `profile_overrides` and moving `profile_override` earlier in the resolution order in `mothership-config/model-policy.yaml`, and update the example policy used by the setup script (`skills/model-policy-setup/scripts/setup-model-policy.sh`).
- Update commander and skill docs (`agents/commander.md`, `skills/*/SKILL.md`, `skills/mothership/SKILL.md`, `skills/task-intake-and-decomposition/SKILL.md`, `AGENTS.md`) to require selecting and recording a profile at intake and to describe how profiles affect research, planning, coding, QA, PR expectations, and model routing.
- Update runtime tooling to support the new policy shape by validating optional `profile_overrides` in `skills/mothership/scripts/validate-model-policy.sh` and adjust bootstrap messaging in `skills/mothership/SKILL.md` to reference `profile_overrides`.
- Adjust text and model resolution order in multiple docs so explicit invocation overrides, profile overrides, risk overrides, role tiers, host mappings, and fallback behave in the intended precedence.

### Testing

- Executed the updated model policy validation script `skills/mothership/scripts/validate-model-policy.sh` against the new example `mothership-config/model-policy.yaml`; the validator recognizes optional `profile_overrides` and returned no validation errors.
- Bootstrapped the example policy using `skills/model-policy-setup/scripts/setup-model-policy.sh` to confirm the sample file is generated with `profile_overrides` and the repository-level references are consistent.
- No other automated test suites were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d61e77c008320a7f102ca6b5ff707)