### PR TITLE
docs: fix documentation-vs-code drift audit findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Mothership Local Agent Instructions
 
-This repository is an installable mothership package for Codex, Claude, and Pi agents and skills.
+This repository is an installable mothership package for Codex, Claude, Antigravity, OpenCode, and Pi agents and skills.
 
 ## Entrypoint
 
@@ -11,6 +11,8 @@ This repository is an installable mothership package for Codex, Claude, and Pi a
 
 - **Claude Code** — uses built-in `Agent` tool for delegation
 - **Codex** — uses built-in `spawn_agent` for delegation
+- **Antigravity** — uses built-in agent tooling for delegation
+- **OpenCode** — maps SKILL.md files as OpenCode commands during install
 - **Pi** — uses `mothership_spawn` extension tool with team-first delegation (requires `skills/mothership/extensions/subagent.ts` and `skills/mothership/extensions/pi-routing.js` installed under `~/.agents/extensions/`).
 
 The Pi extension supports two delegation paths:
@@ -80,7 +82,7 @@ vim mothership-config/model-policy.yaml
 
 The [model-policy.yaml](mothership-config/model-policy.yaml) file controls:
 
-- **host aliases**: Map local host names to supported targets (`claude`, `codex`, `pi`, `hermes`)
+- **host aliases**: Map local host names to supported targets (`claude`, `codex`, `pi`, `hermes`, `ollama`)
 - **role tiers**: Assign model tiers per role (`commander`, `researcher`, `coder`, `qa`, `pr_monkey`)
 - **risk overrides**: Adjust tier selection based on task risk (`low`/`medium`/`high`)
 - **host models**: Define available models per host and tier
@@ -97,6 +99,7 @@ host_aliases:
   codex: codex
   pi: pi
   hermes: hermes
+  ollama: ollama
 
 # Role tiers - map each role to a model tier
 tiers:
@@ -126,7 +129,7 @@ host_models:
 
 Model resolution order:
 1. Role tier + risk override from this file
-2. Host-specific model mapping in `agents/registry.yaml`
+2. Host-specific model mapping in `mothership-config/model-policy.yaml` (host_models section)
 3. Fallback: inherit from current session model
 
 ### Verifying Configuration

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ vim mothership-config/model-policy.yaml
 
 The [model-policy.yaml](mothership-config/model-policy.yaml) file controls:
 
-- **host aliases**: Map local host names to supported targets (`claude`, `codex`, `pi`, `hermes`)
+- **host aliases**: Map local host names to supported targets (`claude`, `codex`, `pi`, `hermes`, `ollama`)
 - **role tiers**: Assign model tiers per role (`commander`, `researcher`, `coder`, `qa`, `pr_monkey`)
 - **risk overrides**: Adjust tier selection based on task risk (`low`/`medium`/`high`)
 - **host models**: Define available models per host and tier
@@ -353,6 +353,7 @@ host_aliases:
   codex: codex
   pi: pi
   hermes: hermes
+  ollama: ollama
 
 # Role tiers - map each role to a model tier
 role_tiers:
@@ -364,9 +365,14 @@ role_tiers:
 
 # Risk overrides - adjust tier based on task risk
 risk_overrides:
-  low: low
-  medium: medium
-  high: high
+  low:
+    coder: low
+    qa: low
+  medium: {}
+  high:
+    researcher: high
+    coder: high
+    qa: high
 
 # Host models - available models per host and tier
 host_models:
@@ -383,8 +389,7 @@ host_models:
 Model resolution order:
 1. Role tier from `role_tiers` + risk override from `risk_overrides` in this file
 2. Host-specific model mapping in `host_models`
-3. Fallback: inherit current thread model (legacy behavior)
-3. Fallback: inherit from current session model
+3. Fallback: inherit from current session model (legacy behavior)
 
 ## Using It
 

--- a/mothership-config/workflow.yaml
+++ b/mothership-config/workflow.yaml
@@ -128,9 +128,10 @@ overlays:
       - complete
       - cleanup
     required_fields:
-      - blocked_reason
-      - blocked_since
-      - next_unblock_action
+      - type
+      - reason
+      - since
+      - unblock
 
   reconstructed:
     purpose: >
@@ -146,9 +147,9 @@ overlays:
       - complete
       - cleanup
     required_fields:
-      - reconstructed_at
-      - reconstruction_source
-      - reconstruction_notes
+      - type
+      - source
+      - notes
 
 runtime_behavior:
   polling:

--- a/skills/mothership/subagent-protocol.md
+++ b/skills/mothership/subagent-protocol.md
@@ -219,8 +219,7 @@ Before leaving a delegated state, commander must have evidence that:
 
 - the delegated sub-agent was actually invoked for that state
 - the delegated sub-agent returned a result or blocker
-- the result was recorded to `refs/<state>.md` and GitHub, with only a
-  reference stored inline in `state.yaml` under the relevant phase section
+- the result was recorded in `state.yaml` under the relevant phase section and to GitHub
 
 This is especially strict for `qa`: commander cannot mark QA complete based on
 its own ad hoc verification after a coder returns.


### PR DESCRIPTION
## Documentation vs Code Drift Audit — June 2026

This PR fixes all drifts found during a comparison of documentation against actual repository structure, tool capabilities, and state machine logic.

### Drifts Corrected

| # | File | Issue | Fix |
|---|------|-------|-----|
| 1 | AGENTS.md | Only listed 3 hosts (Codex, Claude, Pi) but installer supports 5 | Added Antigravity and OpenCode |
| 2 | AGENTS.md + README.md | Host aliases example omitted `ollama` | Added `ollama` to all listings |
| 3 | README.md | Duplicate `Fallback` line (lines 386-387 identical) | Merged into single line |
| 4 | README.md | `risk_overrides` example used flat structure (low/medium/high) | Updated to per-role override structure matching actual `model-policy.yaml` |
| 5 | AGENTS.md | Model resolution order step 2 pointed to `agents/registry.yaml` | Corrected to `mothership-config/model-policy.yaml (host_models section)` |
| 6 | subagent-protocol.md | Still referenced `refs/<state>.md` pattern | Updated to reflect consolidated single-file `state.yaml` hub |
| 7 | workflow.yaml | Overlay field names mismatched hub-contract.md | Aligned `blocked` fields (`blocked_reason`→`type`, `blocked_since`→`reason/since`, `next_unblock_action`→`unblock`) and `reconstructed` fields (`reconstructed_at`→`type`, `reconstruction_source`→`source`, `reconstruction_notes`→`notes`) |

### Items Verified In-Sync

- All 21 SKILL.md files exist and match listings in AGENTS.md and skill-dependencies.md
- Role names (`commander`, `researcher`, `coder`, `qa`, `pr_monkey`) are consistent across registry.yaml, roles.md, README.md, and all agent contracts
- All 5 role contract files exist under `agents/` as claimed
- Workflow states and transitions in README.md match workflow.yaml
- Installer Go source correctly validates all 5 supported targets
- Warmup.sh correctly checks all 5 OBRA skills listed in skill-dependencies.md
- Pi routing path documentation (<base_url>/pi-team, <base_url>/legacy) matches actual extension code