### PR TITLE
docs: fix documentation-vs-code drift audit findings (superset of PR #26)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Mothership Local Agent Instructions
 
-This repository is an installable mothership package for Codex, Claude, and Pi agents and skills.
+This repository is an installable mothership package for Codex, Claude, Antigravity, OpenCode, and Pi agents and skills.
 
 ## Entrypoint
 
@@ -11,6 +11,8 @@ This repository is an installable mothership package for Codex, Claude, and Pi a
 
 - **Claude Code** — uses built-in `Agent` tool for delegation
 - **Codex** — uses built-in `spawn_agent` for delegation
+- **Antigravity** — uses built-in agent tooling for delegation
+- **OpenCode** — maps SKILL.md files as OpenCode commands during install
 - **Pi** — uses `mothership_spawn` extension tool with team-first delegation (requires `skills/mothership/extensions/subagent.ts` and `skills/mothership/extensions/pi-routing.js` installed under `~/.agents/extensions/`).
 
 The Pi extension supports two delegation paths:
@@ -80,7 +82,7 @@ vim mothership-config/model-policy.yaml
 
 The [model-policy.yaml](mothership-config/model-policy.yaml) file controls:
 
-- **host aliases**: Map local host names to supported targets (`claude`, `codex`, `pi`, `hermes`)
+- **host aliases**: Map local host names to supported targets (`claude`, `codex`, `pi`, `hermes`, `ollama`)
 - **role tiers**: Assign model tiers per role (`commander`, `researcher`, `coder`, `qa`, `pr_monkey`)
 - **risk overrides**: Adjust tier selection based on task risk (`low`/`medium`/`high`)
 - **host models**: Define available models per host and tier
@@ -97,20 +99,26 @@ host_aliases:
   codex: codex
   pi: pi
   hermes: hermes
+  ollama: ollama
 
 # Role tiers - map each role to a model tier
-tiers:
+role_tiers:
   commander: high
-  researcher: medium
+  researcher: high
   coder: medium
-  qa: low
+  qa: medium
   pr_monkey: low
 
 # Risk overrides - adjust tier based on task risk
-risk:
-  low: low
-  medium: medium
-  high: high
+risk_overrides:
+  low:
+    coder: low
+    qa: low
+  medium: {}
+  high:
+    researcher: high
+    coder: high
+    qa: high
 
 # Host models - available models per host and tier
 host_models:
@@ -126,7 +134,7 @@ host_models:
 
 Model resolution order:
 1. Role tier + risk override from this file
-2. Host-specific model mapping in `agents/registry.yaml`
+2. Host-specific model mapping in `mothership-config/model-policy.yaml` (host_models section)
 3. Fallback: inherit from current session model
 
 ### Verifying Configuration

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ vim mothership-config/model-policy.yaml
 
 The [model-policy.yaml](mothership-config/model-policy.yaml) file controls:
 
-- **host aliases**: Map local host names to supported targets (`claude`, `codex`, `pi`, `hermes`)
+- **host aliases**: Map local host names to supported targets (`claude`, `codex`, `pi`, `hermes`, `ollama`)
 - **role tiers**: Assign model tiers per role (`commander`, `researcher`, `coder`, `qa`, `pr_monkey`)
 - **risk overrides**: Adjust tier selection based on task risk (`low`/`medium`/`high`)
 - **host models**: Define available models per host and tier
@@ -353,6 +353,7 @@ host_aliases:
   codex: codex
   pi: pi
   hermes: hermes
+  ollama: ollama
 
 # Role tiers - map each role to a model tier
 role_tiers:
@@ -364,9 +365,14 @@ role_tiers:
 
 # Risk overrides - adjust tier based on task risk
 risk_overrides:
-  low: low
-  medium: medium
-  high: high
+  low:
+    coder: low
+    qa: low
+  medium: {}
+  high:
+    researcher: high
+    coder: high
+    qa: high
 
 # Host models - available models per host and tier
 host_models:
@@ -383,8 +389,7 @@ host_models:
 Model resolution order:
 1. Role tier from `role_tiers` + risk override from `risk_overrides` in this file
 2. Host-specific model mapping in `host_models`
-3. Fallback: inherit current thread model (legacy behavior)
-3. Fallback: inherit from current session model
+3. Fallback: inherit from current session model (legacy behavior)
 
 ## Using It
 

--- a/mothership-config/workflow.yaml
+++ b/mothership-config/workflow.yaml
@@ -128,9 +128,10 @@ overlays:
       - complete
       - cleanup
     required_fields:
-      - blocked_reason
-      - blocked_since
-      - next_unblock_action
+      - type
+      - reason
+      - since
+      - unblock
 
   reconstructed:
     purpose: >
@@ -146,9 +147,9 @@ overlays:
       - complete
       - cleanup
     required_fields:
-      - reconstructed_at
-      - reconstruction_source
-      - reconstruction_notes
+      - type
+      - source
+      - notes
 
 runtime_behavior:
   polling:

--- a/skills/model-policy-setup/SKILL.md
+++ b/skills/model-policy-setup/SKILL.md
@@ -6,7 +6,7 @@ description: Bootstrap mothership model policy config. Creates mothership-config
 # Model Policy Setup
 
 Initializes `mothership-config/model-policy.yaml` with defaults for:
-- host aliases (`claude`, `codex`, `pi`, `hermes`)
+- host aliases (`claude`, `codex`, `pi`, `hermes`, `ollama`)
 - role tiers (`commander`, `researcher`, `coder`, `qa`, `pr_monkey`)
 - risk overrides (`low` / `medium` / `high`)
 - host model mapping per tier (`high`, `medium`, `low`)

--- a/skills/mothership/subagent-protocol.md
+++ b/skills/mothership/subagent-protocol.md
@@ -219,8 +219,7 @@ Before leaving a delegated state, commander must have evidence that:
 
 - the delegated sub-agent was actually invoked for that state
 - the delegated sub-agent returned a result or blocker
-- the result was recorded to `refs/<state>.md` and GitHub, with only a
-  reference stored inline in `state.yaml` under the relevant phase section
+- the result was recorded in `state.yaml` under the relevant phase section and to GitHub
 
 This is especially strict for `qa`: commander cannot mark QA complete based on
 its own ad hoc verification after a coder returns.


### PR DESCRIPTION
## Documentation vs Code Drift Audit — June 2026

This PR fixes all drifts found by comparing documentation against actual repository structure, tool capabilities, and state machine logic. It is a superset of PR #26 (same fixes plus additional ones it missed).

### Files Fixed

| # | File | Drift Found | Fix |
|---|------|-------------|-----|
| 1 | AGENTS.md | Only listed 3 hosts (Codex, Claude, Pi) but installer supports 5 | Added Antigravity and OpenCode |
| 2 | AGENTS.md, README.md | Host aliases example omitted `ollama` | Added `ollama` to all listings |
| 3 | AGENTS.md | Used wrong key `tiers:` — actual yaml uses `role_tiers:` | Fixed to `role_tiers:` |
| 4 | AGENTS.md | Used wrong key `risk:` — actual yaml uses `risk_overrides:` | Fixed to `risk_overrides:` |
| 5 | AGENTS.md | Wrong default tiers (researcher:medium→high, qa:low→medium) | Corrected to match actual model-policy.yaml |
| 6 | AGENTS.md | Flat `risk` structure (low/medium/high) but actual is per-role | Updated to per-role override structure |
| 7 | AGENTS.md | Model resolution step 2 pointed to `agents/registry.yaml` | Corrected to `mothership-config/model-policy.yaml (host_models section)` |
| 8 | README.md | Duplicate Fallback line (lines 386-387 identical) | Merged into single line |
| 9 | README.md | `risk_overrides` example used flat structure | Updated to per-role override structure |
| 10 | workflow.yaml | Overlay field names mismatched hub-contract.md | Aligned blocked/reconstructed fields |
| 11 | subagent-protocol.md | Still referenced `refs/<state>.md` pattern | Updated to reflect single-file state.yaml hub |
| 12 | model-policy-setup/SKILL.md | `ollama` missing from host aliases list | Added `ollama` to list |

### Items Verified In-Sync (No Drift)

- All 21 SKILL.md files exist and match listings in AGENTS.md and skill-dependencies.md
- Role names (commander, researcher, coder, qa, pr_monkey) are consistent across registry.yaml, roles.md, README.md, and all agent contracts
- All 5 role contract files exist under agents/ as claimed
- Workflow states and transitions in README.md match workflow.yaml
- Installer Go source correctly validates all 5 supported targets
- Warmup.sh checks all 5 OBRA skills listed in skill-dependencies.md
- Hub contract (hub-contract.md) mirrors runtime copy (.mothership/hub/README.md)
- Model-policy.yaml setup script generates correct `role_tiers:`, `risk_overrides:`, and `ollama` entries