### PR TITLE
docs: fix documentation-vs-code drift audit findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Mothership Local Agent Instructions
 
-This repository is an installable mothership package for Codex, Claude, and Pi agents and skills.
+This repository is an installable mothership package for Codex, Claude, Antigravity, OpenCode, and Pi agents and skills.
 
 ## Entrypoint
 
@@ -11,6 +11,8 @@ This repository is an installable mothership package for Codex, Claude, and Pi a
 
 - **Claude Code** — uses built-in `Agent` tool for delegation
 - **Codex** — uses built-in `spawn_agent` for delegation
+- **Antigravity** — uses built-in agent tooling for delegation
+- **OpenCode** — maps SKILL.md files as OpenCode commands during install
 - **Pi** — uses `mothership_spawn` extension tool with team-first delegation (requires `skills/mothership/extensions/subagent.ts` and `skills/mothership/extensions/pi-routing.js` installed under `~/.agents/extensions/`).
 
 The Pi extension supports two delegation paths:
@@ -99,18 +101,23 @@ host_aliases:
   hermes: hermes
 
 # Role tiers - map each role to a model tier
-tiers:
+role_tiers:
   commander: high
-  researcher: medium
+  researcher: high
   coder: medium
-  qa: low
+  qa: medium
   pr_monkey: low
 
 # Risk overrides - adjust tier based on task risk
-risk:
-  low: low
-  medium: medium
-  high: high
+risk_overrides:
+  low:
+    coder: low
+    qa: low
+  medium: {}
+  high:
+    researcher: high
+    coder: high
+    qa: high
 
 # Host models - available models per host and tier
 host_models:
@@ -126,7 +133,7 @@ host_models:
 
 Model resolution order:
 1. Role tier + risk override from this file
-2. Host-specific model mapping in `agents/registry.yaml`
+2. Host-specific model mapping in `mothership-config/model-policy.yaml` (host_models section)
 3. Fallback: inherit from current session model
 
 ### Verifying Configuration

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ vim mothership-config/model-policy.yaml
 
 The [model-policy.yaml](mothership-config/model-policy.yaml) file controls:
 
-- **host aliases**: Map local host names to supported targets (`claude`, `codex`, `pi`, `hermes`)
+- **host aliases**: Map local host names to supported targets (`claude`, `codex`, `pi`, `hermes`, `ollama`)
 - **role tiers**: Assign model tiers per role (`commander`, `researcher`, `coder`, `qa`, `pr_monkey`)
 - **risk overrides**: Adjust tier selection based on task risk (`low`/`medium`/`high`)
 - **host models**: Define available models per host and tier
@@ -353,6 +353,7 @@ host_aliases:
   codex: codex
   pi: pi
   hermes: hermes
+  ollama: ollama
 
 # Role tiers - map each role to a model tier
 role_tiers:
@@ -364,9 +365,14 @@ role_tiers:
 
 # Risk overrides - adjust tier based on task risk
 risk_overrides:
-  low: low
-  medium: medium
-  high: high
+  low:
+    coder: low
+    qa: low
+  medium: {}
+  high:
+    researcher: high
+    coder: high
+    qa: high
 
 # Host models - available models per host and tier
 host_models:
@@ -383,7 +389,6 @@ host_models:
 Model resolution order:
 1. Role tier from `role_tiers` + risk override from `risk_overrides` in this file
 2. Host-specific model mapping in `host_models`
-3. Fallback: inherit current thread model (legacy behavior)
 3. Fallback: inherit from current session model
 
 ## Using It

--- a/skills/model-policy-setup/SKILL.md
+++ b/skills/model-policy-setup/SKILL.md
@@ -6,7 +6,7 @@ description: Bootstrap mothership model policy config. Creates mothership-config
 # Model Policy Setup
 
 Initializes `mothership-config/model-policy.yaml` with defaults for:
-- host aliases (`claude`, `codex`, `pi`, `hermes`)
+- host aliases (`claude`, `codex`, `pi`, `hermes`, `ollama`)
 - role tiers (`commander`, `researcher`, `coder`, `qa`, `pr_monkey`)
 - risk overrides (`low` / `medium` / `high`)
 - host model mapping per tier (`high`, `medium`, `low`)

--- a/skills/mothership/subagent-protocol.md
+++ b/skills/mothership/subagent-protocol.md
@@ -219,8 +219,7 @@ Before leaving a delegated state, commander must have evidence that:
 
 - the delegated sub-agent was actually invoked for that state
 - the delegated sub-agent returned a result or blocker
-- the result was recorded to `refs/<state>.md` and GitHub, with only a
-  reference stored inline in `state.yaml` under the relevant phase section
+- the result was recorded inline in `state.yaml` under the relevant phase section (e.g., `research:`, `coding:`), and also reflected in GitHub artifacts for durability
 
 This is especially strict for `qa`: commander cannot mark QA complete based on
 its own ad hoc verification after a coder returns.


### PR DESCRIPTION
## Summary

Performed a comprehensive documentation-vs-code drift audit comparing README.md, AGENTS.md, role contracts, and workflow.yaml against the actual repository structure, installer, and configuration.

## Drift Items Found and Fixed

### AGENTS.md
- **Missing host support**: Antigravity and OpenCode were listed in the installer and `tools/installer/main.go` (`supportedTargets`) but absent from AGENTS.md's description and Supported Hosts section.
- **Example YAML incorrect**: Used keys `tiers`/`risk` which do not exist in the actual `mothership-config/model-policy.yaml`. Corrected to `role_tiers`/`risk_overrides` with correct per-role structure. Also fixed incorrect tier assignments (e.g., researcher was set to `medium`, actual default is `high`).
- **Model resolution step**: Referenced `agents/registry.yaml` as model mapping source — the actual host model mapping lives in `mothership-config/model-policy.yaml` (`host_models` section).

### README.md
- **Missing host alias**: `ollama` is present in the actual `model-policy.yaml` but was missing from the host aliases list.
- **Risk overrides example**: Used flat mapping (`low: low`) instead of the actual per-role structure (`low: { coder: low, qa: low }`).
- **Duplicate resolution line**: Two `3. Fallback:` lines at the same numbered level.

### skills/model-policy-setup/SKILL.md
- **Missing host alias**: `ollama` absent from listed host aliases.

### skills/mothership/subagent-protocol.md
- **Stale refs reference**: State Gates section referenced `refs/<state>.md` files, which were replaced by the single-file `state.yaml` hub model. Corrected to match the Hub State Embedding section (inline phase data in `state.yaml`).

## Items Verified as In Sync
- All role names consistent across registry.yaml, roles.md, agent contracts, and README
- Skill dependencies in `skill-dependencies.md` match actual SKILL.md files on disk
- Workflow state machine in `workflow.yaml` matches README's canonical states and overlay descriptions
- All 5 role contract files exist and are referenced correctly
- All 18 supporting SKILL.md files exist and match the skill-dependencies.md listing
