### PR TITLE
docs: fix documentation-vs-code drift audit - 2 files corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,14 @@ role_tiers:
 
 # Risk overrides - adjust tier based on task risk
 risk_overrides:
-  low: low
-  medium: medium
-  high: high
+  low:
+    coder: low
+    qa: low
+  medium: {}
+  high:
+    researcher: high
+    coder: high
+    qa: high
 
 # Host models - available models per host and tier
 host_models:

--- a/skills/mothership/subagent-protocol.md
+++ b/skills/mothership/subagent-protocol.md
@@ -219,8 +219,8 @@ Before leaving a delegated state, commander must have evidence that:
 
 - the delegated sub-agent was actually invoked for that state
 - the delegated sub-agent returned a result or blocker
-- the result was recorded to `refs/<state>.md` and GitHub, with only a
-  reference stored inline in `state.yaml` under the relevant phase section
+- the result was recorded to `state.yaml` under the relevant phase section
+  and GitHub artifacts, for durability across sessions
 
 This is especially strict for `qa`: commander cannot mark QA complete based on
 its own ad hoc verification after a coder returns.


### PR DESCRIPTION
## Summary

This PR fixes two documentation drift issues found during the scheduled documentation-vs-code drift audit.

## Diffs Corrected

### 1. `skills/mothership/subagent-protocol.md` (State Gates section)

**Drift:** Stale reference to `refs/<state>.md` pattern. The hub was consolidated to a single `state.yaml` with no external ref files (see `mothership-config/hub-contract.md`).

**Fix:** Updated to reference `state.yaml` directly and GitHub artifacts for durability.

**Before:**
```
- the result was recorded to `refs/<state>.md` and GitHub, with only a
  reference stored inline in `state.yaml` under the relevant phase section
```

**After:**
```
- the result was recorded to `state.yaml` under the relevant phase section
  and GitHub artifacts, for durability across sessions
```

### 2. `README.md` (Example model-policy configuration)

**Drift:** The example `risk_overrides` section showed a flat format (`low: low`) that did not match the actual canonical `mothership-config/model-policy.yaml`, which uses a nested per-role format.

**Fix:** Updated the example to show the correct nested role-specific format.

**Before:**
```yaml
risk_overrides:
  low: low
  medium: medium
  high: high
```

**After:**
```yaml
risk_overrides:
  low:
    coder: low
    qa: low
  medium: {}
  high:
    researcher: high
    coder: high
    qa: high
```

## Verified No Drift

- **Host support**: Installer targets (`codex`, `claude`, `antigravity`, `opencode`, `pi`) consistent across `AGENTS.md`, `README.md`, and the Go installer
- **Skill availability**: All 18 skills referenced in `skill-dependencies.md` exist in `skills/`
- **Role naming**: `agents/registry.yaml`, `mothership-config/roles.md`, `README.md`, and contract filenames all consistent (`commander`, `researcher`, `coder`, `qa`, `pr_monkey`)
- **Hub contract**: `.mothership/hub/README.md` matches `mothership-config/hub-contract.md`
- **Workflow states**: README state list matches `mothership-config/workflow.yaml`
- **Installer preflight**: validates `skills/`, `agents/`, `mothership-config/`, and `.mothership/hub/README.md` — all present