### PR TITLE
docs: fix documentation-vs-code drift audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Mothership Local Agent Instructions
 
-This repository is an installable mothership package for Codex, Claude, and Pi agents and skills.
+This repository is an installable mothership package for Codex, Claude, Pi, Antigravity, and OpenCode agents and skills.
 
 ## Entrypoint
 
@@ -80,7 +80,7 @@ vim mothership-config/model-policy.yaml
 
 The [model-policy.yaml](mothership-config/model-policy.yaml) file controls:
 
-- **host aliases**: Map local host names to supported targets (`claude`, `codex`, `pi`, `hermes`)
+- **host aliases**: Map local host names to supported targets (`claude`, `codex`, `pi`, `hermes`, `ollama`)
 - **role tiers**: Assign model tiers per role (`commander`, `researcher`, `coder`, `qa`, `pr_monkey`)
 - **risk overrides**: Adjust tier selection based on task risk (`low`/`medium`/`high`)
 - **host models**: Define available models per host and tier
@@ -99,35 +99,64 @@ host_aliases:
   hermes: hermes
 
 # Role tiers - map each role to a model tier
-tiers:
+role_tiers:
   commander: high
-  researcher: medium
+  researcher: high
   coder: medium
-  qa: low
+  qa: medium
   pr_monkey: low
 
 # Risk overrides - adjust tier based on task risk
-risk:
-  low: low
-  medium: medium
-  high: high
+risk_overrides:
+  low:
+    coder: low
+    qa: low
+  medium: {}
+  high:
+    researcher: high
+    coder: high
+    qa: high
 
 # Host models - available models per host and tier
 host_models:
-  pi:
-    high: ["claude-3-5-sonnet-latest", "claude-3-5-haiku-latest"]
-    medium: ["claude-3-5-sonnet-latest", "claude-3-5-haiku-latest"]
-    low: ["claude-3-5-haiku-latest"]
+  claude:
+    high: "claude-opus-4"
+    medium: "claude-sonnet-4"
+    low: "claude-haiku-3.5"
   codex:
-    high: ["claude-3-5-sonnet-latest"]
-    medium: ["claude-3-5-haiku-latest"]
-    low: ["claude-3-5-haiku-latest"]
-```
+    high: "codex/gpt-5.5"
+    medium: "codex/gpt-5.3-codex"
+    low: "codex/gpt-5-mini"
+  pi:
+    high: "openai-codex/gpt-5.5"
+    medium: "openai-codex/gpt-5.3-codex"
+    low: "openai-codex/gpt-5-mini"
+  hermes:
+    high: ""
+    medium: ""
+    low: ""
+  ollama:
+    high: "codex/gpt-5.5"
+    medium: "ollama/deepseek-v4-flash"
+    low: "ollama/kimi-k2.6"
+
+tiers:
+  high:
+    description: "Highest reasoning tier for orchestration and complex implementation."
+    default_model: high
+  medium:
+    description: "Balanced tier for structured execution and reviews."
+    default_model: medium
+  low:
+    description: "Lightweight tier for routine or narrow tasks."
+    default_model: low
 
 Model resolution order:
-1. Role tier + risk override from this file
-2. Host-specific model mapping in `agents/registry.yaml`
-3. Fallback: inherit from current session model
+1. explicit_override
+2. risk_override
+3. role_tier
+4. host_tier_default
+5. inherit_current_thread_model
 
 ### Verifying Configuration
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ vim mothership-config/model-policy.yaml
 
 The [model-policy.yaml](mothership-config/model-policy.yaml) file controls:
 
-- **host aliases**: Map local host names to supported targets (`claude`, `codex`, `pi`, `hermes`)
+- **host aliases**: Map local host names to supported targets (`claude`, `codex`, `pi`, `hermes`, `ollama`)
 - **role tiers**: Assign model tiers per role (`commander`, `researcher`, `coder`, `qa`, `pr_monkey`)
 - **risk overrides**: Adjust tier selection based on task risk (`low`/`medium`/`high`)
 - **host models**: Define available models per host and tier
@@ -353,6 +353,7 @@ host_aliases:
   codex: codex
   pi: pi
   hermes: hermes
+  ollama: ollama
 
 # Role tiers - map each role to a model tier
 role_tiers:
@@ -364,27 +365,56 @@ role_tiers:
 
 # Risk overrides - adjust tier based on task risk
 risk_overrides:
-  low: low
-  medium: medium
-  high: high
+  low:
+    coder: low
+    qa: low
+  medium: {}
+  high:
+    researcher: high
+    coder: high
+    qa: high
 
 # Host models - available models per host and tier
 host_models:
-  pi:
-    high: ["claude-3-5-sonnet-latest", "claude-3-5-haiku-latest"]
-    medium: ["claude-3-5-sonnet-latest", "claude-3-5-haiku-latest"]
-    low: ["claude-3-5-haiku-latest"]
+  claude:
+    high: "claude-opus-4"
+    medium: "claude-sonnet-4"
+    low: "claude-haiku-3.5"
   codex:
-    high: ["claude-3-5-sonnet-latest"]
-    medium: ["claude-3-5-haiku-latest"]
-    low: ["claude-3-5-haiku-latest"]
+    high: "codex/gpt-5.5"
+    medium: "codex/gpt-5.3-codex"
+    low: "codex/gpt-5-mini"
+  pi:
+    high: "openai-codex/gpt-5.5"
+    medium: "openai-codex/gpt-5.3-codex"
+    low: "openai-codex/gpt-5-mini"
+  hermes:
+    high: ""
+    medium: ""
+    low: ""
+  ollama:
+    high: "codex/gpt-5.5"
+    medium: "ollama/deepseek-v4-flash"
+    low: "ollama/kimi-k2.6"
+
+tiers:
+  high:
+    description: "Highest reasoning tier for orchestration and complex implementation."
+    default_model: high
+  medium:
+    description: "Balanced tier for structured execution and reviews."
+    default_model: medium
+  low:
+    description: "Lightweight tier for routine or narrow tasks."
+    default_model: low
 ```
 
 Model resolution order:
-1. Role tier from `role_tiers` + risk override from `risk_overrides` in this file
-2. Host-specific model mapping in `host_models`
-3. Fallback: inherit current thread model (legacy behavior)
-3. Fallback: inherit from current session model
+1. explicit_override (if provided per invocation)
+2. risk_override (if task risk is known)
+3. role_tier (from `role_tiers`)
+4. host_tier_default (from `host_models`)
+5. inherit_current_thread_model (fallback)
 
 ## Using It
 

--- a/skills/mothership/subagent-protocol.md
+++ b/skills/mothership/subagent-protocol.md
@@ -219,8 +219,7 @@ Before leaving a delegated state, commander must have evidence that:
 
 - the delegated sub-agent was actually invoked for that state
 - the delegated sub-agent returned a result or blocker
-- the result was recorded to `refs/<state>.md` and GitHub, with only a
-  reference stored inline in `state.yaml` under the relevant phase section
+- the result was recorded in `state.yaml` under the relevant phase section and to GitHub
 
 This is especially strict for `qa`: commander cannot mark QA complete based on
 its own ad hoc verification after a coder returns.


### PR DESCRIPTION
## Summary

This PR corrects four categories of drift between the repository documentation and the actual code/structure discovered during a systematic audit.

## Fixes Applied

### 1. Missing host support (AGENTS.md)

- **Before:** Claimed support for "Codex, Claude, and Pi" only
- **Reality:** Installer ( line 54) supports 5 targets: `codex`, `claude`, `antigravity`, `opencode`, `pi`
- **Fix:** Updated introductory line and added `ollama` to host aliases list

### 2. Stale model-policy examples (README.md + AGENTS.md)

- Used wrong key names (`tiers:` → `role_tiers:`, `risk:` → `risk_overrides:`)
- Had wrong default tiers (`researcher: medium` → actual `researcher: high`, `qa: low` → actual `qa: medium`)
- Used flat risk_overrides instead of role-scoped structure
- Used old list-format host_models instead of actual string-based per-host mapping
- Missing `tiers:` section with descriptions, `ollama` and `hermes` host entries

### 3. Model resolution order

- Old: merged `role_tier` + `risk_override` into one combined step, referenced `agents/registry.yaml` instead of `host_models`
- Fixed: 5-step resolution order matching `model-policy.yaml` (`explicit_override` → `risk_override` → `role_tier` → `host_tier_default` → `inherit_current_thread_model`)

### 4. Ref references in subagent-protocol.md

- **Before:** State Gates section referenced `refs/<state>.md` files
- **Reality:** Hub contract uses single-file design (`state.yaml` only, with no external refs per `workflow.yaml` line 193)
- **Fix:** Updated to reference `state.yaml` directly

### 5. Duplicate numbering (README.md)

- Model resolution order had duplicate step "3." which was removed.

## Verification

- All 5 role contract files exist in `agents/` and match the registry
- All 21 `SKILL.md` files exist matching `skill-dependencies.md`
- Workflow states in `README.md` match `workflow.yaml`
- Installer targets confirmed via Go source inspection